### PR TITLE
Fixed missing Logs directory

### DIFF
--- a/OWML.Launcher/App.cs
+++ b/OWML.Launcher/App.cs
@@ -42,6 +42,8 @@ namespace OWML.Launcher
 
             CopyGameFiles();
 
+            CreateLogsDirectory();
+
             var hasPortArgument = CommandLineArguments.HasArgument(Constants.ConsolePortArgument);
             if (!hasPortArgument)
             {
@@ -167,5 +169,12 @@ namespace OWML.Launcher
             Environment.Exit(0);
         }
 
+        private void CreateLogsDirectory()
+        {
+            if (!Directory.Exists("Logs"))
+            {
+                Directory.CreateDirectory("Logs");
+            }
+        }
     }
 }

--- a/OWML.Launcher/OWML.Manifest.json
+++ b/OWML.Launcher/OWML.Manifest.json
@@ -2,6 +2,6 @@
   "author": "Alek",
   "name": "OWML",
   "uniqueName": "Alek.OWML",
-  "version": "0.3.49",
+  "version": "0.3.50",
   "description": "The mod loader and mod framework for Outer Wilds"
 }

--- a/OWML.Launcher/OWML.Manifest.json
+++ b/OWML.Launcher/OWML.Manifest.json
@@ -2,6 +2,6 @@
   "author": "Alek",
   "name": "OWML",
   "uniqueName": "Alek.OWML",
-  "version": "0.3.50",
+  "version": "0.3.51",
   "description": "The mod loader and mod framework for Outer Wilds"
 }

--- a/OWML.Launcher/OutputListener.cs
+++ b/OWML.Launcher/OutputListener.cs
@@ -22,10 +22,6 @@ namespace OWML.Launcher
 
         public void Start()
         {
-            if (!Directory.Exists("Logs"))
-            {
-                Directory.CreateDirectory("Logs");
-            }
             File.WriteAllText(_config.OutputFilePath, "");
             _reader = File.Open(_config.OutputFilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
             Task.Run(Work);

--- a/OWML.SampleMods/OWML.EnableDebugMode/manifest.json
+++ b/OWML.SampleMods/OWML.EnableDebugMode/manifest.json
@@ -4,6 +4,6 @@
   "name": "EnableDebugMode",
   "uniqueName": "Alek.EnableDebugMode",
   "version": "0.2",
-  "owmlVersion": "0.3.49",
+  "owmlVersion": "0.3.50",
   "description": "Enables the debug mode in Outer Wilds"
 }

--- a/OWML.SampleMods/OWML.EnableDebugMode/manifest.json
+++ b/OWML.SampleMods/OWML.EnableDebugMode/manifest.json
@@ -4,6 +4,6 @@
   "name": "EnableDebugMode",
   "uniqueName": "Alek.EnableDebugMode",
   "version": "0.2",
-  "owmlVersion": "0.3.50",
+  "owmlVersion": "0.3.51",
   "description": "Enables the debug mode in Outer Wilds"
 }

--- a/OWML.SampleMods/OWML.LoadCustomAssets/manifest.json
+++ b/OWML.SampleMods/OWML.LoadCustomAssets/manifest.json
@@ -4,6 +4,6 @@
   "name": "LoadCustomAssets",
   "uniqueName": "Alek.LoadCustomAssets",
   "version": "0.5",
-  "owmlVersion": "0.3.50",
+  "owmlVersion": "0.3.51",
   "description": "A mod for testing loading of custom assets"
 }

--- a/OWML.SampleMods/OWML.LoadCustomAssets/manifest.json
+++ b/OWML.SampleMods/OWML.LoadCustomAssets/manifest.json
@@ -4,6 +4,6 @@
   "name": "LoadCustomAssets",
   "uniqueName": "Alek.LoadCustomAssets",
   "version": "0.5",
-  "owmlVersion": "0.3.49",
+  "owmlVersion": "0.3.50",
   "description": "A mod for testing loading of custom assets"
 }

--- a/createrelease.bat
+++ b/createrelease.bat
@@ -1,7 +1,6 @@
 rmdir /Q /S "Release"
 mkdir "Release"
 mkdir "Release\Mods"
-mkdir "Release\Logs"
 mkdir "Release\VR"
 
 copy "OWML.Patcher\bin\Debug\OWML.Patcher.dll" "Release\OWML.Patcher.dll"


### PR DESCRIPTION
When launching from the Mod Manager, `OutputListener` isn't created, so the Logs directory wasn't being created either. So I moved the creation of this directory to outside that class.

Seems like the test releases created by `createrelease.bat` weren't exactly replicating the structure of a real release, which is why we didn't catch this problem sooner. So I removed the empty Logs directory from the test releases.