### PR TITLE
moved CommandLineArguments.cs to ModHelper

### DIFF
--- a/OWML.Common/IModInputCombination.cs
+++ b/OWML.Common/IModInputCombination.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 using UnityEngine;
 
 namespace OWML.Common

--- a/OWML.Common/OWML.Common.csproj
+++ b/OWML.Common/OWML.Common.csproj
@@ -32,7 +32,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="CommandLineArguments.cs" />
     <Compile Include="Constants.cs" />
     <Compile Include="Events.cs" />
     <Compile Include="IHarmonyHelper.cs" />

--- a/OWML.Launcher/App.cs
+++ b/OWML.Launcher/App.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Newtonsoft.Json;
 using OWML.Common;
 using OWML.GameFinder;
+using OWML.ModHelper;
 using OWML.Patcher;
 
 namespace OWML.Launcher

--- a/OWML.ModHelper.Input/Properties/AssemblyInfo.cs
+++ b/OWML.ModHelper.Input/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following

--- a/OWML.ModHelper/CommandLineArguments.cs
+++ b/OWML.ModHelper/CommandLineArguments.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
-namespace OWML.Common
+namespace OWML.ModHelper
 {
     public static class CommandLineArguments
     {

--- a/OWML.ModHelper/OWML.ModHelper.csproj
+++ b/OWML.ModHelper/OWML.ModHelper.csproj
@@ -73,6 +73,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CommandLineArguments.cs" />
     <Compile Include="ControllerButton.cs" />
     <Compile Include="DontDestroyOnLoad.cs" />
     <Compile Include="ModBehaviour.cs" />

--- a/OWML.ModHelper/OWML.ModHelper.csproj.DotSettings
+++ b/OWML.ModHelper/OWML.ModHelper.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=logging/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
Just so there's less chance we'll end up putting all sorts of random stuff in Common in the future ;)
Common is intended to only be for interfaces and global enums and constants.