### PR TITLE
Keep user config consistent with default configs

### DIFF
--- a/OWML.Common/IModConfig.cs
+++ b/OWML.Common/IModConfig.cs
@@ -14,5 +14,8 @@ namespace OWML.Common
 
         [Obsolete("Use GetSettingsValue instead")]
         T GetSetting<T>(string key);
+
+        void MakeConsistentWithDefaults(IModConfig defaultConfig);
+        void ResetToDefaults(IModConfig defaultConfig);
     }
 }

--- a/OWML.ModHelper.Menus/ModConfigMenu.cs
+++ b/OWML.ModHelper.Menus/ModConfigMenu.cs
@@ -60,9 +60,7 @@ namespace OWML.ModHelper.Menus
 
         protected override void OnReset()
         {
-            ModData.Config.Enabled = ModData.DefaultConfig.Enabled;
-            ModData.Config.RequireVR = ModData.DefaultConfig.RequireVR;
-            ModData.Config.Settings = new Dictionary<string, object>(ModData.DefaultConfig.Settings);
+            ModData.Config.ResetToDefaults(ModData.DefaultConfig);
             UpdateUIValues();
         }
     }

--- a/OWML.ModHelper.Menus/ModConfigMenu.cs
+++ b/OWML.ModHelper.Menus/ModConfigMenu.cs
@@ -13,7 +13,7 @@ namespace OWML.ModHelper.Menus
         public IModData ModData { get; }
         public IModBehaviour Mod { get; }
 
-        public ModConfigMenu(IModConsole console, IModData modData, IModBehaviour mod) 
+        public ModConfigMenu(IModConsole console, IModData modData, IModBehaviour mod)
             : base(console, modData.Manifest)
         {
             ModData = modData;

--- a/OWML.ModHelper/ModConfig.cs
+++ b/OWML.ModHelper/ModConfig.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using OWML.Common;
@@ -80,12 +81,10 @@ namespace OWML.ModHelper
                 if (!defaultConfig.Settings.ContainsKey(setting.Key))
                 {
                     settingsCopy.Remove(setting.Key);
-                    continue;
                 }
                 else if (!IsSettingSameType(setting.Value, defaultConfig.Settings[setting.Key]))
                 {
                     settingsCopy[setting.Key] = defaultConfig.Settings[setting.Key];
-                    continue;
                 }
             }
             Settings = settingsCopy;
@@ -93,29 +92,15 @@ namespace OWML.ModHelper
 
         private void AddMissingDefaults(IModConfig defaultConfig)
         {
-            foreach (var defaultSetting in defaultConfig.Settings)
-            {
-                if (!Settings.ContainsKey(defaultSetting.Key))
-                {
-                    Settings.Add(defaultSetting.Key, defaultSetting.Value);
-                }
-            }
+            var missingSettings = defaultConfig.Settings.Where(s => !Settings.ContainsKey(s.Key)).ToList();
+            missingSettings.ForEach(setting => Settings.Add(setting.Key, setting.Value));
         }
 
         private bool IsSettingSameType(object settingValue1, object settingValue2)
         {
-            if (settingValue1.GetType() != settingValue2.GetType())
-            {
-                return false;
-            }
-            if (settingValue1 is JObject obj1 && settingValue2 is JObject obj2)
-            {
-                if ((string)obj1["type"] != (string)obj2["type"])
-                {
-                    return false;
-                }
-            }
-            return true;
+            return settingValue1.GetType() == settingValue2.GetType() &&
+                   (!(settingValue1 is JObject obj1) || !(settingValue2 is JObject obj2) ||
+                    (string)obj1["type"] == (string)obj2["type"]);
         }
     }
 }

--- a/OWML.ModHelper/ModConfig.cs
+++ b/OWML.ModHelper/ModConfig.cs
@@ -65,17 +65,6 @@ namespace OWML.ModHelper
             return GetSettingsValue<T>(key);
         }
 
-        private void AddMissingDefaults(IModConfig defaultConfig)
-        {
-            foreach (var defaultSetting in defaultConfig.Settings)
-            {
-                if (!Settings.ContainsKey(defaultSetting.Key))
-                {
-                    Settings.Add(defaultSetting.Key, defaultSetting.Value);
-                }
-            }
-        }
-
         public void MakeConfigConsistentWithDefaults(IModConfig defaultConfig)
         {
             if (defaultConfig == null)
@@ -100,6 +89,17 @@ namespace OWML.ModHelper
                 }
             }
             Settings = settingsCopy;
+        }
+
+        private void AddMissingDefaults(IModConfig defaultConfig)
+        {
+            foreach (var defaultSetting in defaultConfig.Settings)
+            {
+                if (!Settings.ContainsKey(defaultSetting.Key))
+                {
+                    Settings.Add(defaultSetting.Key, defaultSetting.Value);
+                }
+            }
         }
 
         private bool IsSettingSameType(object settingValue1, object settingValue2)

--- a/OWML.ModHelper/ModConfig.cs
+++ b/OWML.ModHelper/ModConfig.cs
@@ -65,5 +65,57 @@ namespace OWML.ModHelper
             return GetSettingsValue<T>(key);
         }
 
+        private void AddMissingDefaults(IModConfig defaultConfig)
+        {
+            foreach (var defaultSetting in defaultConfig.Settings)
+            {
+                if (!Settings.ContainsKey(defaultSetting.Key))
+                {
+                    Settings.Add(defaultSetting.Key, defaultSetting.Value);
+                }
+            }
+        }
+
+        public void MakeConfigConsistentWithDefaults(IModConfig defaultConfig)
+        {
+            if (defaultConfig == null)
+            {
+                return;
+            }
+
+            AddMissingDefaults(defaultConfig);
+
+            var settingsCopy = new Dictionary<string, object>(Settings);
+            foreach (var setting in Settings)
+            {
+                if (!defaultConfig.Settings.ContainsKey(setting.Key))
+                {
+                    settingsCopy.Remove(setting.Key);
+                    continue;
+                }
+                else if (!IsSettingSameType(setting.Value, defaultConfig.Settings[setting.Key]))
+                {
+                    settingsCopy[setting.Key] = defaultConfig.Settings[setting.Key];
+                    continue;
+                }
+            }
+            Settings = settingsCopy;
+        }
+
+        private bool IsSettingSameType(object settingValue1, object settingValue2)
+        {
+            if (settingValue1.GetType() != settingValue2.GetType())
+            {
+                return false;
+            }
+            if (settingValue1 is JObject obj1 && settingValue2 is JObject obj2)
+            {
+                if ((string)obj1["type"] != (string)obj2["type"])
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
     }
 }

--- a/OWML.ModHelper/ModConfig.cs
+++ b/OWML.ModHelper/ModConfig.cs
@@ -66,7 +66,14 @@ namespace OWML.ModHelper
             return GetSettingsValue<T>(key);
         }
 
-        public void MakeConfigConsistentWithDefaults(IModConfig defaultConfig)
+        public void ResetToDefaults(IModConfig defaultConfig)
+        {
+            Enabled = defaultConfig.Enabled;
+            RequireVR = defaultConfig.RequireVR;
+            Settings = new Dictionary<string, object>(defaultConfig.Settings);
+        }
+
+        public void MakeConsistentWithDefaults(IModConfig defaultConfig)
         {
             if (defaultConfig == null)
             {

--- a/OWML.ModLoader/ModFinder.cs
+++ b/OWML.ModLoader/ModFinder.cs
@@ -53,17 +53,12 @@ namespace OWML.ModLoader
             }
             else if (defaultConfig != null)
             {
-                foreach (var setting in defaultConfig.Settings)
-                {
-                    if (!config.Settings.ContainsKey(setting.Key))
-                    {
-                        config.Settings.Add(setting.Key, setting.Value);
-                    }
-                }
+                config.MakeConfigConsistentWithDefaults(defaultConfig);
             }
+
+
             storage.Save(config, "config.json");
             return new ModData(manifest, config, defaultConfig);
         }
-
     }
 }

--- a/OWML.ModLoader/ModFinder.cs
+++ b/OWML.ModLoader/ModFinder.cs
@@ -53,7 +53,7 @@ namespace OWML.ModLoader
             }
             else if (defaultConfig != null)
             {
-                config.MakeConfigConsistentWithDefaults(defaultConfig);
+                config.MakeConsistentWithDefaults(defaultConfig);
             }
             storage.Save(config, "config.json");
             return new ModData(manifest, config, defaultConfig);

--- a/OWML.ModLoader/ModFinder.cs
+++ b/OWML.ModLoader/ModFinder.cs
@@ -55,8 +55,6 @@ namespace OWML.ModLoader
             {
                 config.MakeConfigConsistentWithDefaults(defaultConfig);
             }
-
-
             storage.Save(config, "config.json");
             return new ModData(manifest, config, defaultConfig);
         }


### PR DESCRIPTION
Closes #208 

Prevents problems when a mod update changes the type of a setting. To achieve consistency between user config and default config, we do this:

1. Add missing default properties to user config (was already happening before this change);
2. Remove options that are in user config, but not in default config;
3. Reset options to default if type in user config is different than type in default config.

For step 1, I've moved some logic from `ModFinder` to `ModConfig`'s `AddMissingDefaults()` method.