### PR TITLE
Show slider value in mod settings

### DIFF
--- a/OWML.Common/Menus/IModSliderInput.cs
+++ b/OWML.Common/Menus/IModSliderInput.cs
@@ -4,6 +4,7 @@
     {
         float Min { get; set; }
         float Max { get; set; }
+        bool HasValueText { get; }
 
         IModSliderInput Copy();
         IModSliderInput Copy(string title);

--- a/OWML.ModHelper.Menus/ModSliderInput.cs
+++ b/OWML.ModHelper.Menus/ModSliderInput.cs
@@ -54,9 +54,14 @@ namespace OWML.ModHelper.Menus
         private void OnValueChanged()
         {
             InvokeOnChange(Value);
+            UpdateValueText();
+        }
+
+        private void UpdateValueText()
+        {
             if (_valueText != null)
             {
-                _valueText.text = Value.ToString();
+                _valueText.text = string.Format("{0:0.#}", Value);
             }
         }
 

--- a/OWML.ModHelper.Menus/ModSliderInput.cs
+++ b/OWML.ModHelper.Menus/ModSliderInput.cs
@@ -47,17 +47,16 @@ namespace OWML.ModHelper.Menus
         private Text GetValueText()
         {
             var slider = _element.GetComponentInChildren<Slider>();
-            if (slider != null)
-            {
-                return slider.GetComponentInChildren<Text>();
-            }
-            return null;
+            return slider?.GetComponentInChildren<Text>();
         }
 
         private void OnValueChanged()
         {
             InvokeOnChange(Value);
-            _valueText.text = Value.ToString();
+            if (_valueText != null)
+            {
+                _valueText.text = Value.ToString();
+            }
         }
 
         private float ToRealNumber(float fakeNumber)

--- a/OWML.ModHelper.Menus/ModSliderInput.cs
+++ b/OWML.ModHelper.Menus/ModSliderInput.cs
@@ -1,6 +1,7 @@
 ﻿using OWML.Common.Menus;
 using OWML.ModHelper.Events;
 using UnityEngine;
+using UnityEngine.UI;
 
 namespace OWML.ModHelper.Menus
 {
@@ -8,20 +9,23 @@ namespace OWML.ModHelper.Menus
     {
         public float Min { get; set; }
         public float Max { get; set; }
+        public bool HasValueText => _valueText != null;
         public override bool IsSelected => _uIStyleApplier?.GetValue<bool>("_selected") ?? false;
 
         private readonly SliderElement _element;
+        private readonly Text _valueText;
+
         private readonly UIStyleApplier _uIStyleApplier;
 
         public ModSliderInput(SliderElement element, IModMenu menu) : base(element, menu)
         {
             _element = element;
+            _valueText = GetValueText();
             _uIStyleApplier = element.GetComponent<UIStyleApplier>();
-            element.OnValueChanged += () => InvokeOnChange(Value);
+            element.OnValueChanged += OnValueChanged;
         }
 
-        public override float Value
-        {
+        public override float Value {
             get => ToRealNumber(_element.GetValue());
             set => _element.Initialize((int)ToFakeNumber(value));
         }
@@ -40,6 +44,22 @@ namespace OWML.ModHelper.Menus
             return copy;
         }
 
+        private Text GetValueText()
+        {
+            var slider = _element.GetComponentInChildren<Slider>();
+            if (slider != null)
+            {
+                return slider.GetComponentInChildren<Text>();
+            }
+            return null;
+        }
+
+        private void OnValueChanged()
+        {
+            InvokeOnChange(Value);
+            _valueText.text = Value.ToString();
+        }
+
         private float ToRealNumber(float fakeNumber)
         {
             return fakeNumber * (Max - Min) / 10;
@@ -49,6 +69,5 @@ namespace OWML.ModHelper.Menus
         {
             return realNumber * 10 / (Max - Min);
         }
-
     }
 }

--- a/OWML.ModHelper.Menus/ModSliderInput.cs
+++ b/OWML.ModHelper.Menus/ModSliderInput.cs
@@ -25,7 +25,8 @@ namespace OWML.ModHelper.Menus
             element.OnValueChanged += OnValueChanged;
         }
 
-        public override float Value {
+        public override float Value
+        {
             get => ToRealNumber(_element.GetValue());
             set => _element.Initialize((int)ToFakeNumber(value));
         }

--- a/OWML.ModHelper.Menus/ModsMenu.cs
+++ b/OWML.ModHelper.Menus/ModsMenu.cs
@@ -94,7 +94,7 @@ namespace OWML.ModHelper.Menus
         private void InitConfigMenu(IModConfigMenuBase modConfigMenu, IModTabbedMenu options)
         {
             var toggleTemplate = options.InputTab.ToggleInputs[0];
-            var sliderTemplate = options.InputTab.SliderInputs[0];
+            var sliderTemplate = options.GraphicsTab.SliderInputs.Find(sliderInput => sliderInput.HasValueText) ?? options.InputTab.SliderInputs[0];
             var textInputTemplate = new ModTextInput(toggleTemplate.Copy().Toggle, modConfigMenu, _menus.InputMenu);
             textInputTemplate.Hide();
             var comboInputTemplate = new ModComboInput(toggleTemplate.Copy().Toggle, modConfigMenu, _menus.InputCombinationMenu, _inputHandler);

--- a/OWML.SampleMods/OWML.LoadCustomAssets/default-config.json
+++ b/OWML.SampleMods/OWML.LoadCustomAssets/default-config.json
@@ -19,6 +19,12 @@
       "min": 0,
       "max": 20
     },
+    "decimals": {
+      "type": "slider",
+      "value": 10.54545,
+      "min": 0.545,
+      "max": 525.545845565
+    },
     "thing": {
       "type": "selector",
       "options": [ "A", "B", "C" ],


### PR DESCRIPTION
There does't seem to be a way to just toggle the display of the value inside the slider handle; seems like the elements are created in the editor, and then the text has to be updated manually (which is kinda crazy).

Had to change the slider template since the one being used before didn't include this text inside the handle.

I made it so every slider always shows the currently selected value. Could make it optional, but I felt like it was unnecessary.

Closes #223 