### PR TITLE
fix events

### DIFF
--- a/OWML.Common/IModAsset.cs
+++ b/OWML.Common/IModAsset.cs
@@ -4,6 +4,9 @@ namespace OWML.Common
 {
     public interface IModAsset<T>
     {
+        event Action<T> OnCompleted;
+
+        [Obsolete("Use OnCompleted instead.")]
         Action<T> OnLoaded { get; set; }
     }
 }

--- a/OWML.Common/IModAsset.cs
+++ b/OWML.Common/IModAsset.cs
@@ -4,9 +4,9 @@ namespace OWML.Common
 {
     public interface IModAsset<T>
     {
-        event Action<T> OnCompleted;
+        event Action<T> Loaded;
 
-        [Obsolete("Use OnCompleted instead.")]
+        [Obsolete("Use Loaded instead.")]
         Action<T> OnLoaded { get; set; }
     }
 }

--- a/OWML.Common/IModEvents.cs
+++ b/OWML.Common/IModEvents.cs
@@ -8,9 +8,9 @@ namespace OWML.Common
         IModPlayerEvents Player { get; }
         IModSceneEvents Scenes { get; }
 
-        event Action<MonoBehaviour, Events> OnEvent2;
+        event Action<MonoBehaviour, Events> Event;
 
-        [Obsolete("Use OnEvent2 instead.")]
+        [Obsolete("Use Event instead.")]
         Action<MonoBehaviour, Events> OnEvent { get; set; }
 
         void Subscribe<T>(Events ev) where T : MonoBehaviour;

--- a/OWML.Common/IModEvents.cs
+++ b/OWML.Common/IModEvents.cs
@@ -8,6 +8,9 @@ namespace OWML.Common
         IModPlayerEvents Player { get; }
         IModSceneEvents Scenes { get; }
 
+        event Action<MonoBehaviour, Events> OnEvent2;
+
+        [Obsolete("Use OnEvent2 instead.")]
         Action<MonoBehaviour, Events> OnEvent { get; set; }
 
         void Subscribe<T>(Events ev) where T : MonoBehaviour;

--- a/OWML.Common/Menus/IModPopupMenu.cs
+++ b/OWML.Common/Menus/IModPopupMenu.cs
@@ -5,7 +5,12 @@ namespace OWML.Common.Menus
 {
     public interface IModPopupMenu : IModMenu
     {
+        event Action OnOpened;
+        event Action OnClosed;
+
+        [Obsolete("Use OnOpened instead.")]
         Action OnOpen { get; set; }
+        [Obsolete("Use OnClosed instead.")]
         Action OnClose { get; set; }
 
         bool IsOpen { get; }

--- a/OWML.ModHelper.Assets/ModAsset.cs
+++ b/OWML.ModHelper.Assets/ModAsset.cs
@@ -6,6 +6,9 @@ namespace OWML.ModHelper.Assets
 {
     public class ModAsset<T> : MonoBehaviour, IModAsset<T>
     {
+        public event Action<T> OnCompleted;
+
+        [Obsolete("Use OnCompleted instead.")]
         public Action<T> OnLoaded { get; set; }
 
         public T Asset { get; private set; }
@@ -14,6 +17,7 @@ namespace OWML.ModHelper.Assets
         {
             Asset = asset;
             OnLoaded?.Invoke(asset);
+            OnCompleted?.Invoke(asset);
         }
 
         private void Start()

--- a/OWML.ModHelper.Assets/ModAsset.cs
+++ b/OWML.ModHelper.Assets/ModAsset.cs
@@ -8,7 +8,7 @@ namespace OWML.ModHelper.Assets
     {
         public event Action<T> Loaded;
 
-        [Obsolete("Use OnCompleted instead.")]
+        [Obsolete("Use Loaded instead.")]
         public Action<T> OnLoaded { get; set; }
 
         public T Asset { get; private set; }

--- a/OWML.ModHelper.Assets/ModAsset.cs
+++ b/OWML.ModHelper.Assets/ModAsset.cs
@@ -6,7 +6,7 @@ namespace OWML.ModHelper.Assets
 {
     public class ModAsset<T> : MonoBehaviour, IModAsset<T>
     {
-        public event Action<T> OnCompleted;
+        public event Action<T> Loaded;
 
         [Obsolete("Use OnCompleted instead.")]
         public Action<T> OnLoaded { get; set; }
@@ -17,7 +17,7 @@ namespace OWML.ModHelper.Assets
         {
             Asset = asset;
             OnLoaded?.Invoke(asset);
-            OnCompleted?.Invoke(asset);
+            Loaded?.Invoke(asset);
         }
 
         private void Start()

--- a/OWML.ModHelper.Events/ModEvents.cs
+++ b/OWML.ModHelper.Events/ModEvents.cs
@@ -11,9 +11,9 @@ namespace OWML.ModHelper.Events
         public IModPlayerEvents Player { get; }
         public IModSceneEvents Scenes { get; }
 
-        public event Action<MonoBehaviour, Common.Events> OnEvent2; // todo name
+        public event Action<MonoBehaviour, Common.Events> Event;
 
-        [Obsolete("Use OnEvent2 instead.")]
+        [Obsolete("Use Event instead.")]
         public Action<MonoBehaviour, Common.Events> OnEvent { get; set; }
 
         private static readonly List<KeyValuePair<Type, Common.Events>> PatchedEvents = new List<KeyValuePair<Type, Common.Events>>();
@@ -41,7 +41,7 @@ namespace OWML.ModHelper.Events
             {
                 _logger.Log($"Got subscribed event: {ev} of {type.Name}");
                 OnEvent?.Invoke(behaviour, ev);
-                OnEvent2?.Invoke(behaviour, ev);
+                Event?.Invoke(behaviour, ev);
             }
             else
             {

--- a/OWML.ModHelper.Events/ModEvents.cs
+++ b/OWML.ModHelper.Events/ModEvents.cs
@@ -11,6 +11,9 @@ namespace OWML.ModHelper.Events
         public IModPlayerEvents Player { get; }
         public IModSceneEvents Scenes { get; }
 
+        public event Action<MonoBehaviour, Common.Events> OnEvent2; // todo name
+
+        [Obsolete("Use OnEvent2 instead.")]
         public Action<MonoBehaviour, Common.Events> OnEvent { get; set; }
 
         private static readonly List<KeyValuePair<Type, Common.Events>> PatchedEvents = new List<KeyValuePair<Type, Common.Events>>();
@@ -38,6 +41,7 @@ namespace OWML.ModHelper.Events
             {
                 _logger.Log($"Got subscribed event: {ev} of {type.Name}");
                 OnEvent?.Invoke(behaviour, ev);
+                OnEvent2?.Invoke(behaviour, ev);
             }
             else
             {

--- a/OWML.ModHelper.Events/ModPlayerEvents.cs
+++ b/OWML.ModHelper.Events/ModPlayerEvents.cs
@@ -11,7 +11,7 @@ namespace OWML.ModHelper.Events
         public ModPlayerEvents(IModEvents events)
         {
             events.Subscribe<PlayerBody>(Common.Events.AfterAwake);
-            events.OnEvent2 += OnEvent;
+            events.Event += OnEvent;
         }
 
         private void OnEvent(MonoBehaviour behaviour, Common.Events ev)

--- a/OWML.ModHelper.Events/ModPlayerEvents.cs
+++ b/OWML.ModHelper.Events/ModPlayerEvents.cs
@@ -11,7 +11,7 @@ namespace OWML.ModHelper.Events
         public ModPlayerEvents(IModEvents events)
         {
             events.Subscribe<PlayerBody>(Common.Events.AfterAwake);
-            events.OnEvent += OnEvent;
+            events.OnEvent2 += OnEvent;
         }
 
         private void OnEvent(MonoBehaviour behaviour, Common.Events ev)

--- a/OWML.ModHelper.Events/Patches.cs
+++ b/OWML.ModHelper.Events/Patches.cs
@@ -7,7 +7,7 @@ namespace OWML.ModHelper.Events
 {
     internal static class Patches
     {
-        public static Action<MonoBehaviour, Common.Events> OnEvent { get; set; }
+        public static event Action<MonoBehaviour, Common.Events> OnEvent;
 
         public static void BeforeAwake(MonoBehaviour __instance) => OnEvent?.Invoke(__instance, Common.Events.BeforeAwake);
         public static void AfterAwake(MonoBehaviour __instance) => OnEvent?.Invoke(__instance, Common.Events.AfterAwake);

--- a/OWML.ModHelper.Input/BindingChangeListener.cs
+++ b/OWML.ModHelper.Input/BindingChangeListener.cs
@@ -12,7 +12,7 @@ namespace OWML.ModHelper.Input
         {
             _inputHandler = inputHandler;
             events.Subscribe<TitleScreenManager>(Common.Events.AfterStart);
-            events.OnEvent += OnEvent;
+            events.OnEvent2 += OnEvent;
         }
 
         private void OnEvent(MonoBehaviour behaviour, Common.Events ev)

--- a/OWML.ModHelper.Input/BindingChangeListener.cs
+++ b/OWML.ModHelper.Input/BindingChangeListener.cs
@@ -12,7 +12,7 @@ namespace OWML.ModHelper.Input
         {
             _inputHandler = inputHandler;
             events.Subscribe<TitleScreenManager>(Common.Events.AfterStart);
-            events.OnEvent2 += OnEvent;
+            events.Event += OnEvent;
         }
 
         private void OnEvent(MonoBehaviour behaviour, Common.Events ev)

--- a/OWML.ModHelper.Menus/ModComboInput.cs
+++ b/OWML.ModHelper.Menus/ModComboInput.cs
@@ -81,7 +81,7 @@ namespace OWML.ModHelper.Menus
         private void OnCancel()
         {
             InputMenu.OnConfirm -= OnConfirm;
-            InputMenu.OnClose -= OnCancel;
+            InputMenu.OnClosed -= OnCancel;
         }
 
         public IModComboInput Copy()

--- a/OWML.ModHelper.Menus/ModMenus.cs
+++ b/OWML.ModHelper.Menus/ModMenus.cs
@@ -28,7 +28,7 @@ namespace OWML.ModHelper.Menus
 
             events.Subscribe<SettingsManager>(Common.Events.AfterStart);
             events.Subscribe<TitleScreenManager>(Common.Events.AfterStart);
-            events.OnEvent += OnEvent;
+            events.OnEvent2 += OnEvent;
         }
 
         private void OnEvent(MonoBehaviour behaviour, Common.Events ev)

--- a/OWML.ModHelper.Menus/ModMenus.cs
+++ b/OWML.ModHelper.Menus/ModMenus.cs
@@ -28,7 +28,7 @@ namespace OWML.ModHelper.Menus
 
             events.Subscribe<SettingsManager>(Common.Events.AfterStart);
             events.Subscribe<TitleScreenManager>(Common.Events.AfterStart);
-            events.OnEvent2 += OnEvent;
+            events.Event += OnEvent;
         }
 
         private void OnEvent(MonoBehaviour behaviour, Common.Events ev)

--- a/OWML.ModHelper.Menus/ModPopupMenu.cs
+++ b/OWML.ModHelper.Menus/ModPopupMenu.cs
@@ -9,7 +9,12 @@ namespace OWML.ModHelper.Menus
 {
     public class ModPopupMenu : ModMenu, IModPopupMenu
     {
+        public event Action OnOpened;
+        public event Action OnClosed;
+
+        [Obsolete("Use OnOpened instead.")]
         public Action OnOpen { get; set; }
+        [Obsolete("Use OnClosed instead.")]
         public Action OnClose { get; set; }
 
         public bool IsOpen { get; private set; }
@@ -41,12 +46,14 @@ namespace OWML.ModHelper.Menus
         {
             IsOpen = false;
             OnClose?.Invoke();
+            OnClosed?.Invoke();
         }
 
         private void OnActivateMenu()
         {
             IsOpen = true;
             OnOpen?.Invoke();
+            OnOpened?.Invoke();
         }
 
         public virtual void Open()

--- a/OWML.SampleMods/OWML.EnableDebugMode/EnableDebugMode.cs
+++ b/OWML.SampleMods/OWML.EnableDebugMode/EnableDebugMode.cs
@@ -39,7 +39,7 @@ namespace OWML.EnableDebugMode
             ModHelper.Console.WriteLine($"In {nameof(EnableDebugMode)}!", MessageType.Info);
             ModHelper.HarmonyHelper.EmptyMethod<DebugInputManager>("Awake");
             ModHelper.Events.Subscribe<PlayerSpawner>(Events.AfterAwake);
-            ModHelper.Events.OnEvent += OnEvent;
+            ModHelper.Events.OnEvent2 += OnEvent;
         }
 
         private void OnEvent(MonoBehaviour behaviour, Events ev)

--- a/OWML.SampleMods/OWML.EnableDebugMode/EnableDebugMode.cs
+++ b/OWML.SampleMods/OWML.EnableDebugMode/EnableDebugMode.cs
@@ -39,7 +39,7 @@ namespace OWML.EnableDebugMode
             ModHelper.Console.WriteLine($"In {nameof(EnableDebugMode)}!", MessageType.Info);
             ModHelper.HarmonyHelper.EmptyMethod<DebugInputManager>("Awake");
             ModHelper.Events.Subscribe<PlayerSpawner>(Events.AfterAwake);
-            ModHelper.Events.OnEvent2 += OnEvent;
+            ModHelper.Events.Event += OnEvent;
         }
 
         private void OnEvent(MonoBehaviour behaviour, Events ev)

--- a/OWML.SampleMods/OWML.LoadCustomAssets/LoadCustomAssets.cs
+++ b/OWML.SampleMods/OWML.LoadCustomAssets/LoadCustomAssets.cs
@@ -37,11 +37,11 @@ namespace OWML.LoadCustomAssets
             _cube = assetBundle.LoadAsset<GameObject>("Cube");
 
             var gunSoundAsset = ModHelper.Assets.LoadAudio("blaster-firing.wav");
-            gunSoundAsset.OnCompleted += OnGunSoundLoaded;
+            gunSoundAsset.Loaded += OnGunSoundLoaded;
             var duckAsset = ModHelper.Assets.Load3DObject("duck.obj", "duck.png");
-            duckAsset.OnCompleted += OnDuckLoaded;
+            duckAsset.Loaded += OnDuckLoaded;
             var musicAsset = ModHelper.Assets.LoadAudio("spiral-mountain.mp3");
-            musicAsset.OnCompleted += OnMusicLoaded;
+            musicAsset.Loaded += OnMusicLoaded;
 
             ModHelper.Events.Player.OnPlayerAwake += OnPlayerAwake;
             ModHelper.Events.Scenes.OnStartSceneChange += OnStartSceneChange;

--- a/OWML.SampleMods/OWML.LoadCustomAssets/LoadCustomAssets.cs
+++ b/OWML.SampleMods/OWML.LoadCustomAssets/LoadCustomAssets.cs
@@ -37,11 +37,11 @@ namespace OWML.LoadCustomAssets
             _cube = assetBundle.LoadAsset<GameObject>("Cube");
 
             var gunSoundAsset = ModHelper.Assets.LoadAudio("blaster-firing.wav");
-            gunSoundAsset.OnLoaded += OnGunSoundLoaded;
+            gunSoundAsset.OnCompleted += OnGunSoundLoaded;
             var duckAsset = ModHelper.Assets.Load3DObject("duck.obj", "duck.png");
-            duckAsset.OnLoaded += OnDuckLoaded;
+            duckAsset.OnCompleted += OnDuckLoaded;
             var musicAsset = ModHelper.Assets.LoadAudio("spiral-mountain.mp3");
-            musicAsset.OnLoaded += OnMusicLoaded;
+            musicAsset.OnCompleted += OnMusicLoaded;
 
             ModHelper.Events.Player.OnPlayerAwake += OnPlayerAwake;
             ModHelper.Events.Scenes.OnStartSceneChange += OnStartSceneChange;


### PR DESCRIPTION
`public Action` can be nulled from any mod, while `public event Action` is regulated - mods can only change their own subscription.
Most Actions are proper events, but some of the first ones aren't. This has been bothering me for months.
Adding the event keyword is **not** backwards compatible, therefore I'm adding new (proper) events.
Suggestions for better names for new events are welcome.