### PR TITLE
migrated input events

### DIFF
--- a/OWML.Common/IModEvents.cs
+++ b/OWML.Common/IModEvents.cs
@@ -7,6 +7,7 @@ namespace OWML.Common
     {
         IModPlayerEvents Player { get; }
         IModSceneEvents Scenes { get; }
+        IModInputEvents Input { get; }
         IModUnityEvents Unity { get; }
 
         event Action<MonoBehaviour, Events> Event;

--- a/OWML.Common/IModInputEvents.cs
+++ b/OWML.Common/IModInputEvents.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace OWML.Common
+{
+    public interface IModInputEvents
+    {
+        event Action<SingleAxisCommand> OnNewlyPressed;
+        event Action<SingleAxisCommand> OnNewlyReleased;
+        event Action<SingleAxisCommand> OnNewlyHeld;
+        event Action<SingleAxisCommand> OnPressed;
+        event Action<SingleAxisCommand> OnTapped;
+        event Action<SingleAxisCommand> OnHeld;
+
+        void AddToListener(SingleAxisCommand command);
+        void RemoveFromListener(SingleAxisCommand command);
+        void BlockNextRelease();
+    }
+}

--- a/OWML.Common/OWML.Common.csproj
+++ b/OWML.Common/OWML.Common.csproj
@@ -38,6 +38,7 @@
     <Compile Include="IModAssets.cs" />
     <Compile Include="IModAsset.cs" />
     <Compile Include="IModInputCombination.cs" />
+    <Compile Include="IModInputEvents.cs" />
     <Compile Include="IModInputTextures.cs" />
     <Compile Include="IModInputHandler.cs" />
     <Compile Include="IModInteraction.cs" />

--- a/OWML.ModHelper.Events/ModEvents.cs
+++ b/OWML.ModHelper.Events/ModEvents.cs
@@ -10,6 +10,7 @@ namespace OWML.ModHelper.Events
     {
         public IModPlayerEvents Player { get; }
         public IModSceneEvents Scenes { get; }
+        public IModInputEvents Input { get; }
         public IModUnityEvents Unity { get; }
 
         public event Action<MonoBehaviour, Common.Events> Event;
@@ -33,6 +34,7 @@ namespace OWML.ModHelper.Events
 
             Player = new ModPlayerEvents(this);
             Scenes = new ModSceneEvents();
+            Input = new GameObject().AddComponent<ModInputEvents>();
             Unity = new GameObject().AddComponent<ModUnityEvents>();
         }
 

--- a/OWML.ModHelper.Events/ModInputEvents.cs
+++ b/OWML.ModHelper.Events/ModInputEvents.cs
@@ -1,22 +1,22 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using OWML.Common;
 using UnityEngine;
-using OWML.ModHelper.Events;
 
-namespace OWML.ModHelper.Input
+namespace OWML.ModHelper.Events
 {
-    public class ModCommandListener : MonoBehaviour
+    public class ModInputEvents : MonoBehaviour, IModInputEvents
     {
+        private const float MinimalPressDuration = 0.1f;
+        private const float MaximalTapDuration = 0.1f;
+
         public event Action<SingleAxisCommand> OnNewlyPressed;
         public event Action<SingleAxisCommand> OnNewlyReleased;
         public event Action<SingleAxisCommand> OnNewlyHeld;
         public event Action<SingleAxisCommand> OnPressed;
         public event Action<SingleAxisCommand> OnTapped;
         public event Action<SingleAxisCommand> OnHeld;
-
-        public float MinimalPressDuration { get; set; } = 0.1f;
-        public float MaximalTapDuration { get; set; } = 0.1f;
 
         private readonly HashSet<SingleAxisCommand> _commands = new HashSet<SingleAxisCommand>();
         private readonly HashSet<SingleAxisCommand> _toRemove = new HashSet<SingleAxisCommand>();

--- a/OWML.ModHelper.Events/OWML.ModHelper.Events.csproj
+++ b/OWML.ModHelper.Events/OWML.ModHelper.Events.csproj
@@ -72,6 +72,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="HarmonyHelper.cs" />
+    <Compile Include="ModInputEvents.cs" />
     <Compile Include="ModEvents.cs" />
     <Compile Include="ModUnityEvents.cs" />
     <Compile Include="Patches.cs" />

--- a/OWML.ModHelper.Input/OWML.ModHelper.Input.csproj
+++ b/OWML.ModHelper.Input/OWML.ModHelper.Input.csproj
@@ -74,7 +74,6 @@
   <ItemGroup>
     <Compile Include="InputInterceptor.cs" />
     <Compile Include="BindingChangeListener.cs" />
-    <Compile Include="ModCommandListener.cs" />
     <Compile Include="ModCommandUpdater.cs" />
     <Compile Include="ModInputCombination.cs" />
     <Compile Include="ModInputHandler.cs" />

--- a/OWML.ModHelper.Menus/ModComboInput.cs
+++ b/OWML.ModHelper.Menus/ModComboInput.cs
@@ -25,8 +25,8 @@ namespace OWML.ModHelper.Menus
             }
         }
 
-        public ModComboInput(TwoButtonToggleElement element, IModMenu menu, IModInputCombinationMenu inputMenu, IModInputHandler inputHandler)
-            : base(element, menu)
+        public ModComboInput(TwoButtonToggleElement element, IModMenu menu, IModInputCombinationMenu inputMenu, IModInputHandler inputHandler, IModEvents events)
+            : base(element, menu, events)
         {
             _inputHandler = inputHandler;
             InputMenu = inputMenu;
@@ -88,7 +88,7 @@ namespace OWML.ModHelper.Menus
         {
             var copy = Object.Instantiate(ToggleElement);
             Object.Destroy(copy.GetComponentInChildren<LocalizedText>(true));
-            return new ModComboInput(copy, Menu, InputMenu, _inputHandler);
+            return new ModComboInput(copy, Menu, InputMenu, _inputHandler, Events);
         }
 
         public IModComboInput Copy(string title)

--- a/OWML.ModHelper.Menus/ModConfigMenu.cs
+++ b/OWML.ModHelper.Menus/ModConfigMenu.cs
@@ -11,8 +11,8 @@ namespace OWML.ModHelper.Menus
         public IModData ModData { get; }
         public IModBehaviour Mod { get; }
 
-        public ModConfigMenu(IModConsole console, IModData modData, IModBehaviour mod)
-            : base(console, modData.Manifest)
+        public ModConfigMenu(IModConsole console, IModData modData, IModBehaviour mod, IModEvents events)
+            : base(console, modData.Manifest, events)
         {
             ModData = modData;
             Mod = mod;

--- a/OWML.ModHelper.Menus/ModConfigMenuBase.cs
+++ b/OWML.ModHelper.Menus/ModConfigMenuBase.cs
@@ -21,7 +21,8 @@ namespace OWML.ModHelper.Menus
         protected abstract void AddInputs();
         protected abstract void UpdateUIValues();
 
-        protected ModConfigMenuBase(IModConsole console, IModManifest manifest) : base(console)
+        protected ModConfigMenuBase(IModConsole console, IModManifest manifest, IModEvents events)
+            : base(console, events)
         {
             Manifest = manifest;
             Storage = new ModStorage(manifest);
@@ -50,7 +51,7 @@ namespace OWML.ModHelper.Menus
             base.Open();
             UpdateUIValues();
         }
-        
+
         protected void AddConfigInput(string key, object value, int index)
         {
             if (value is bool)

--- a/OWML.ModHelper.Menus/ModFieldInput.cs
+++ b/OWML.ModHelper.Menus/ModFieldInput.cs
@@ -1,4 +1,5 @@
-﻿using OWML.Common.Menus;
+﻿using OWML.Common;
+using OWML.Common.Menus;
 using OWML.ModHelper.Events;
 using UnityEngine.UI;
 
@@ -10,7 +11,8 @@ namespace OWML.ModHelper.Menus
 
         protected readonly IModInputMenu InputMenu;
 
-        protected ModFieldInput(TwoButtonToggleElement toggle, IModMenu menu, IModInputMenu inputMenu) : base(toggle, menu)
+        protected ModFieldInput(TwoButtonToggleElement toggle, IModMenu menu, IModInputMenu inputMenu, IModEvents events) 
+            : base(toggle, menu, events)
         {
             Button = new ModTitleButton(toggle.GetValue<Button>("_buttonTrue"), menu);
             Subscribe(Button);

--- a/OWML.ModHelper.Menus/ModInputCombinationElement.cs
+++ b/OWML.ModHelper.Menus/ModInputCombinationElement.cs
@@ -24,6 +24,7 @@ namespace OWML.ModHelper.Menus
 
         private string _combination;
         private readonly IModInputHandler _inputHandler;
+        private readonly IModEvents _events;
         private readonly List<SingleAxisCommand> _openCommands = new List<SingleAxisCommand>
         {
             InputLibrary.menuConfirm
@@ -31,11 +32,12 @@ namespace OWML.ModHelper.Menus
 
         private static IModInputCombinationElementMenu _popupMenu;
 
-        public ModInputCombinationElement(TwoButtonToggleElement toggle, IModMenu menu,
-            IModInputCombinationElementMenu popupMenu, IModInputHandler inputHandler, string combination = "") :
+        public ModInputCombinationElement(TwoButtonToggleElement toggle, IModMenu menu, 
+            IModInputCombinationElementMenu popupMenu, IModInputHandler inputHandler, IModEvents events, string combination = "") :
             base(toggle, menu)
         {
             _inputHandler = inputHandler;
+            _events = events;
             _combination = combination;
             Initialize(menu);
             SetupButtons();
@@ -66,11 +68,9 @@ namespace OWML.ModHelper.Menus
 
         private void SetupButtons()
         {
-            var commandObject = new GameObject();
-            var commandComponent = commandObject.AddComponent<ModCommandListener>();
-            _openCommands.ForEach(commandComponent.AddToListener);
-            commandComponent.OnNewlyReleased += OnEditButton;
-            commandComponent.BlockNextRelease();
+            _openCommands.ForEach(_events.Input.AddToListener);
+            _events.Input.OnNewlyReleased += OnEditButton;
+            _events.Input.BlockNextRelease();
             YesButton.Title = "Edit";
             YesButton.OnClick += OnEditClick;
 
@@ -78,13 +78,12 @@ namespace OWML.ModHelper.Menus
             var deleteBindingGamepad = new InputBinding(JoystickButton.FaceLeft);
             var deleteBindingKeyboard = new InputBinding(KeyCode.Delete);
             deleteCommand.SetInputs(deleteBindingGamepad, deleteBindingKeyboard);
-            commandObject = new GameObject();
+            var commandObject = new GameObject();
             var updater = commandObject.AddComponent<ModCommandUpdater>();
             updater.Initialize(deleteCommand);
-            commandComponent = commandObject.AddComponent<ModCommandListener>();
-            commandComponent.AddToListener(deleteCommand);
-            commandComponent.OnNewlyReleased += OnDeleteButton;
-            commandComponent.BlockNextRelease();
+            _events.Input.AddToListener(deleteCommand);
+            _events.Input.OnNewlyReleased += OnDeleteButton;
+            _events.Input.BlockNextRelease();
             NoButton.Title = "Delete";
             NoButton.OnClick += OnDeleteClick;
         }
@@ -186,7 +185,7 @@ namespace OWML.ModHelper.Menus
         {
             var copy = Object.Instantiate(Toggle);
             Object.Destroy(copy.GetComponentInChildren<LocalizedText>(true));
-            return new ModInputCombinationElement(copy, Menu, _popupMenu, _inputHandler, combination);
+            return new ModInputCombinationElement(copy, Menu, _popupMenu, _inputHandler, _events, combination);
         }
     }
 }

--- a/OWML.ModHelper.Menus/ModInputCombinationMenu.cs
+++ b/OWML.ModHelper.Menus/ModInputCombinationMenu.cs
@@ -17,7 +17,7 @@ namespace OWML.ModHelper.Menus
 
         private IModInputCombinationElement _combinationElementTemplate;
 
-        public ModInputCombinationMenu(IModConsole console) : base(console)
+        public ModInputCombinationMenu(IModConsole console, IModEvents events) : base(console, events)
         {
             CombinationElements = new List<IModInputCombinationElement>();
         }

--- a/OWML.ModHelper.Menus/ModMenuWithSelectables.cs
+++ b/OWML.ModHelper.Menus/ModMenuWithSelectables.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using OWML.Common;
 using OWML.Common.Menus;
 using OWML.ModHelper.Events;
-using OWML.ModHelper.Input;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -15,21 +14,23 @@ namespace OWML.ModHelper.Menus
         public event Action OnCancel;
 
         protected List<Selectable> Selectables;
-        protected ModCommandListener CommandListener;
 
-        protected ModMenuWithSelectables(IModConsole console) : base(console) { }
+        private readonly IModEvents _events;
+
+        protected ModMenuWithSelectables(IModConsole console, IModEvents events) : base(console)
+        {
+            _events = events;
+        }
 
         private void SetupCommands()
         {
-            var listenerObject = new GameObject("ConfigurationMenu_Listener");
-            CommandListener = listenerObject.AddComponent<ModCommandListener>();
-            CommandListener.AddToListener(InputLibrary.confirm);
-            CommandListener.AddToListener(InputLibrary.enter2);//keypad's Enter
-            CommandListener.AddToListener(InputLibrary.cancel);
-            CommandListener.AddToListener(InputLibrary.escape);
-            CommandListener.AddToListener(InputLibrary.setDefaults);
-            CommandListener.OnNewlyReleased += OnButton;
-            listenerObject.SetActive(false);
+            _events.Input.AddToListener(InputLibrary.confirm);
+            _events.Input.AddToListener(InputLibrary.enter2);//keypad's Enter
+            _events.Input.AddToListener(InputLibrary.cancel);
+            _events.Input.AddToListener(InputLibrary.escape);
+            _events.Input.AddToListener(InputLibrary.setDefaults);
+            _events.Input.OnNewlyReleased += OnButton;
+            //listenerObject.SetActive(false); todo hmmm? :)
         }
 
         protected virtual void SetupButtons()
@@ -67,10 +68,7 @@ namespace OWML.ModHelper.Menus
                 .Single(x => x.name == "Content");
             Initialize(menu, layoutGroup);
 
-            if (CommandListener == null)
-            {
-                SetupCommands();
-            }
+            SetupCommands();
             SetupButtons();
 
             GetTitleButton("UIElement-CancelOutOfRebinding")?.Hide();
@@ -151,13 +149,13 @@ namespace OWML.ModHelper.Menus
 
         protected virtual void OnActivateMenu()
         {
-            CommandListener.gameObject.SetActive(true);
-            CommandListener.BlockNextRelease();
+            //CommandListener.gameObject.SetActive(true); // todo hmmmm
+            _events.Input.BlockNextRelease();
         }
 
         protected virtual void OnDeactivateMenu()
         {
-            CommandListener.gameObject.SetActive(false);
+            //CommandListener.gameObject.SetActive(false); // todo hmmmm
         }
 
         protected virtual void OnButton(SingleAxisCommand command)

--- a/OWML.ModHelper.Menus/ModMenus.cs
+++ b/OWML.ModHelper.Menus/ModMenus.cs
@@ -22,11 +22,11 @@ namespace OWML.ModHelper.Menus
             MainMenu = new ModMainMenu(console);
             PauseMenu = new ModPauseMenu(console);
             ModsMenu = new ModsMenu(console, this, inputHandler, events);
-            OwmlMenu = new OwmlConfigMenu(console, owmlManifest, owmlConfig, owmlDefaultConfig);
+            OwmlMenu = new OwmlConfigMenu(console, owmlManifest, owmlConfig, owmlDefaultConfig, events);
             InputMenu = new ModInputMenu(console);
             InputCombinationElementMenu = new ModInputCombinationElementMenu(console, inputHandler);
             MessagePopup = InputCombinationElementMenu.MessagePopup;
-            InputCombinationMenu = new ModInputCombinationMenu(console);
+            InputCombinationMenu = new ModInputCombinationMenu(console, events);
 
             events.Subscribe<SettingsManager>(Common.Events.AfterStart);
             events.Subscribe<TitleScreenManager>(Common.Events.AfterStart);

--- a/OWML.ModHelper.Menus/ModNumberInput.cs
+++ b/OWML.ModHelper.Menus/ModNumberInput.cs
@@ -1,5 +1,6 @@
 ﻿using OWML.Common.Menus;
 using System;
+using OWML.Common;
 using Object = UnityEngine.Object;
 
 namespace OWML.ModHelper.Menus
@@ -8,9 +9,8 @@ namespace OWML.ModHelper.Menus
     {
         private float _value;
 
-        public ModNumberInput(TwoButtonToggleElement element, IModMenu menu, IModInputMenu inputMenu) : base(element, menu, inputMenu)
-        {
-        }
+        public ModNumberInput(TwoButtonToggleElement element, IModMenu menu, IModInputMenu inputMenu, IModEvents events)
+            : base(element, menu, inputMenu, events) { }
 
         protected override void Open()
         {
@@ -47,7 +47,7 @@ namespace OWML.ModHelper.Menus
         {
             var copy = Object.Instantiate(ToggleElement);
             Object.Destroy(copy.GetComponentInChildren<LocalizedText>(true));
-            return new ModNumberInput(copy, Menu, InputMenu);
+            return new ModNumberInput(copy, Menu, InputMenu, Events);
         }
 
         public IModNumberInput Copy(string title)

--- a/OWML.ModHelper.Menus/ModPopupInput.cs
+++ b/OWML.ModHelper.Menus/ModPopupInput.cs
@@ -1,8 +1,7 @@
 ﻿using System.Collections.Generic;
+using OWML.Common;
 using OWML.Common.Menus;
 using OWML.ModHelper.Events;
-using OWML.ModHelper.Input;
-using UnityEngine;
 using UnityEngine.UI;
 using UnityEngine.EventSystems;
 
@@ -11,7 +10,6 @@ namespace OWML.ModHelper.Menus
     public abstract class ModPopupInput<T> : ModInput<T>
     {
         protected readonly TwoButtonToggleElement ToggleElement;
-        protected ModCommandListener CommandListener;
 
         public override bool IsSelected => ToggleElement.GetValue<bool>("_amISelected");
 
@@ -22,9 +20,12 @@ namespace OWML.ModHelper.Menus
             InputLibrary.enter2
         };
 
-        protected ModPopupInput(TwoButtonToggleElement toggle, IModMenu menu) : base(toggle, menu)
+        protected readonly IModEvents Events;
+
+        protected ModPopupInput(TwoButtonToggleElement toggle, IModMenu menu, IModEvents events) : base(toggle, menu)
         {
             ToggleElement = toggle;
+            Events = events;
 
             var noButton = ToggleElement.GetValue<Button>("_buttonFalse");
             noButton.transform.parent.gameObject.SetActive(false);
@@ -41,10 +42,8 @@ namespace OWML.ModHelper.Menus
 
         private void SetupCommands()
         {
-            var listenerObject = new GameObject();
-            CommandListener = listenerObject.AddComponent<ModCommandListener>();
-            _openCommands.ForEach(CommandListener.AddToListener);
-            CommandListener.OnNewlyPressed += OnOpenCommand;
+            _openCommands.ForEach(Events.Input.AddToListener);
+            Events.Input.OnNewlyPressed += OnOpenCommand;
         }
 
         protected void Subscribe(IModButtonBase button)

--- a/OWML.ModHelper.Menus/ModTextInput.cs
+++ b/OWML.ModHelper.Menus/ModTextInput.cs
@@ -1,4 +1,5 @@
-﻿using OWML.Common.Menus;
+﻿using OWML.Common;
+using OWML.Common.Menus;
 using UnityEngine;
 
 namespace OWML.ModHelper.Menus
@@ -7,9 +8,8 @@ namespace OWML.ModHelper.Menus
     {
         private string _value;
 
-        public ModTextInput(TwoButtonToggleElement element, IModMenu menu, IModInputMenu inputMenu) : base(element, menu, inputMenu)
-        {
-        }
+        public ModTextInput(TwoButtonToggleElement element, IModMenu menu, IModInputMenu inputMenu, IModEvents events)
+            : base(element, menu, inputMenu, events) { }
 
         protected override void Open()
         {
@@ -46,7 +46,7 @@ namespace OWML.ModHelper.Menus
         {
             var copy = Object.Instantiate(ToggleElement);
             Object.Destroy(copy.GetComponentInChildren<LocalizedText>(true));
-            return new ModTextInput(copy, Menu, InputMenu);
+            return new ModTextInput(copy, Menu, InputMenu, Events);
         }
 
         public IModTextInput Copy(string title)

--- a/OWML.ModHelper.Menus/ModsMenu.cs
+++ b/OWML.ModHelper.Menus/ModsMenu.cs
@@ -28,7 +28,7 @@ namespace OWML.ModHelper.Menus
 
         public void AddMod(IModData modData, IModBehaviour mod)
         {
-            _modConfigMenus.Add(new ModConfigMenu(OwmlConsole, modData, mod));
+            _modConfigMenus.Add(new ModConfigMenu(OwmlConsole, modData, mod, _events));
         }
 
         public IModConfigMenu GetModMenu(IModBehaviour modBehaviour)
@@ -61,14 +61,14 @@ namespace OWML.ModHelper.Menus
 
         private void InitCombinationMenu(IModTabbedMenu options)
         {
-            options.OnClose += () => OnDeactivateOptions(options);
+            options.OnClosed += () => OnDeactivateOptions(options);
             if (_menus.InputCombinationMenu.Menu != null)
             {
                 return;
             }
             var toggleTemplate = options.InputTab.ToggleInputs[0].Copy().Toggle;
             var comboElementTemplate = new ModInputCombinationElement(toggleTemplate,
-                _menus.InputCombinationMenu, _menus.InputCombinationElementMenu, _inputHandler);
+                _menus.InputCombinationMenu, _menus.InputCombinationElementMenu, _inputHandler, _events);
             comboElementTemplate.Hide();
             var rebindMenuTemplate = options.RebindingMenu.Copy().Menu;
             _menus.InputCombinationMenu.Initialize(rebindMenuTemplate, comboElementTemplate);
@@ -121,11 +121,11 @@ namespace OWML.ModHelper.Menus
             var toggleTemplate = options.InputTab.ToggleInputs[0];
             var sliderTemplate = options.GraphicsTab.SliderInputs.Find(sliderInput => sliderInput.HasValueText) ?? options.InputTab.SliderInputs[0];
             var selectorTemplate = options.GraphicsTab.SelectorInputs[0];
-            var textInputTemplate = new ModTextInput(toggleTemplate.Copy().Toggle, modConfigMenu, _menus.InputMenu);
+            var textInputTemplate = new ModTextInput(toggleTemplate.Copy().Toggle, modConfigMenu, _menus.InputMenu, _events);
             textInputTemplate.Hide();
-            var comboInputTemplate = new ModComboInput(toggleTemplate.Copy().Toggle, modConfigMenu, _menus.InputCombinationMenu, _inputHandler);
+            var comboInputTemplate = new ModComboInput(toggleTemplate.Copy().Toggle, modConfigMenu, _menus.InputCombinationMenu, _inputHandler, _events);
             comboInputTemplate.Hide();
-            var numberInputTemplate = new ModNumberInput(toggleTemplate.Copy().Toggle, modConfigMenu, _menus.InputMenu);
+            var numberInputTemplate = new ModNumberInput(toggleTemplate.Copy().Toggle, modConfigMenu, _menus.InputMenu, _events);
             numberInputTemplate.Hide();
             var rebindMenuCopy = options.RebindingMenu.Copy().Menu;
             modConfigMenu.Initialize(rebindMenuCopy, toggleTemplate, sliderTemplate, textInputTemplate,

--- a/OWML.ModHelper.Menus/OwmlConfigMenu.cs
+++ b/OWML.ModHelper.Menus/OwmlConfigMenu.cs
@@ -10,8 +10,8 @@ namespace OWML.ModHelper.Menus
         private readonly IOwmlConfig _config;
         private readonly IOwmlConfig _defaultConfig;
 
-        public OwmlConfigMenu(IModConsole console, IModManifest manifest, IOwmlConfig config, IOwmlConfig defaultConfig)
-            : base(console, manifest)
+        public OwmlConfigMenu(IModConsole console, IModManifest manifest, IOwmlConfig config, IOwmlConfig defaultConfig, IModEvents events)
+            : base(console, manifest, events)
         {
             _config = config;
             _defaultConfig = defaultConfig;


### PR DESCRIPTION
Some comments:
* Input events are now global and shared. Side-effects?
* Added some `todo` comments where I didn't know what to do.
* ModEvents are now passed around in menus *a lot*, might wanna consider a singleton to access OWML's event object.

@TAImatem feel free to take over this branch/PR (or start from scratch if this is crap), you know the input system much better than me.