### PR TITLE
disabling mod menus if not v1.0.7

### DIFF
--- a/OWML.ModHelper.Menus/ModMenus.cs
+++ b/OWML.ModHelper.Menus/ModMenus.cs
@@ -24,6 +24,13 @@ namespace OWML.ModHelper.Menus
             PopupManager = new ModPopupManager(console, inputHandler, events);
             InputCombinationMenu = new ModInputCombinationMenu(console);
 
+            const string supportedVersion = "1.0.7";
+            if (!Application.version.StartsWith(supportedVersion))
+            {
+                console.WriteLine($"Warning - Only version {supportedVersion} is supported for modded menus.\n" +
+                                  "Please update the game.", MessageType.Warning);
+                return;
+            }
             events.Subscribe<SettingsManager>(Common.Events.AfterStart);
             events.Subscribe<TitleScreenManager>(Common.Events.AfterStart);
             events.Event += OnEvent;


### PR DESCRIPTION
This simply doesn't initialize mod menus unless game version starts with 1.0.7. 
OWML works otherwise fine, except: mods that try to do menu stuff will produce errors, but it doesn't seem to crash the game.
It's not a permanent fix but better than what we have now.