### PR TITLE
Wait before closing socket on fatal error

### DIFF
--- a/OWML.Logging/ModSocket.cs
+++ b/OWML.Logging/ModSocket.cs
@@ -2,6 +2,7 @@
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
+using System.Threading;
 using Newtonsoft.Json;
 using OWML.Common;
 
@@ -10,6 +11,7 @@ namespace OWML.Logging
     public class ModSocket : IModSocket
     {
         private readonly Socket _socket;
+        private const int _closeWaitSeconds = 1;
 
         public ModSocket(int port)
         {
@@ -32,6 +34,7 @@ namespace OWML.Logging
 
         public void Close()
         {
+            Thread.Sleep(TimeSpan.FromSeconds(_closeWaitSeconds));
             _socket.Close();
         }
     }


### PR DESCRIPTION
In some very specific cases, messages can be lost when closing the socket, meaning the game would crash without showing the fatal error message.

I'm using Thread.Sleep but I felt like it was alright since it's only for shutting down the game. Any better way to wait?

I tried a lot of other stuff to make the socket close gracefully without failing to send a message, but for whatever reason none of it worked. It only seems to be a problem with the mod manager, so I suspect it is a problem with node closing the socket too soon on that side, but I had no luck fixing the problem in the manager's end.