### PR TITLE
Value-only user config

### DIFF
--- a/OWML.Common/IModConfig.cs
+++ b/OWML.Common/IModConfig.cs
@@ -10,7 +10,5 @@ namespace OWML.Common
 
         T GetSettingsValue<T>(string key);
         void SetSettingsValue(string key, object value);
-
-        IModConfig Copy();
     }
 }

--- a/OWML.Common/IModMergedConfig.cs
+++ b/OWML.Common/IModMergedConfig.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace OWML.Common
+﻿namespace OWML.Common
 {
     public interface IModMergedConfig : IModConfig
     {
         void SaveToStorage();
+        IModConfig Copy();
     }
 }

--- a/OWML.ModHelper/ModConfig.cs
+++ b/OWML.ModHelper/ModConfig.cs
@@ -71,15 +71,5 @@ namespace OWML.ModHelper
         {
             Settings[key] = value;
         }
-
-        public IModConfig Copy()
-        {
-            return new ModConfig
-            {
-                Enabled = Enabled,
-                Settings = new Dictionary<string, object>(Settings)
-            };
-        }
-
     }
 }

--- a/OWML.ModHelper/ModConfig.cs
+++ b/OWML.ModHelper/ModConfig.cs
@@ -29,7 +29,7 @@ namespace OWML.ModHelper
         private T GetSettingsValue<T>(string key, object setting)
         {
             var type = typeof(T);
-            
+
             try
             {
                 var value = setting is JObject objectValue ? objectValue["value"] : setting;
@@ -69,20 +69,7 @@ namespace OWML.ModHelper
 
         public void SetSettingsValue(string key, object value)
         {
-            if (!Settings.ContainsKey(key))
-            {
-                ModConsole.OwmlConsole.WriteLine("Error - Setting not found: " + key, MessageType.Error);
-                return;
-            }
-
-            if (Settings[key] is JObject setting)
-            {
-                setting["value"] = JToken.FromObject(value);
-            }
-            else
-            {
-                Settings[key] = value;
-            }
+            Settings[key] = value;
         }
 
         public IModConfig Copy()

--- a/OWML.ModHelper/ModMergedConfig.cs
+++ b/OWML.ModHelper/ModMergedConfig.cs
@@ -15,7 +15,7 @@ namespace OWML.ModHelper
             set => _userConfig.Settings = value;
         }
 
-        private IModConfig _userConfig;
+        private readonly IModConfig _userConfig;
         private readonly IModConfig _defaultConfig;
         private readonly IModStorage _storage;
 
@@ -38,7 +38,7 @@ namespace OWML.ModHelper
 
         public void SetSettingsValue(string key, object value)
         {
-            _userConfig.SetSettingsValue(key, value);
+            _userConfig.SetSettingsValue(key, GetConvertedSelectorValue(key, value) ?? value);
         }
 
         public IModConfig Copy()
@@ -106,6 +106,21 @@ namespace OWML.ModHelper
                 return true;
             }
             return userValue.GetType() == defaultInnerValue.GetType();
+        }
+
+        private object GetConvertedSelectorValue(string key, object value)
+        {
+            if (!_defaultConfig.Settings.ContainsKey(key))
+            {
+                return null;
+            }
+            var defaultValue = _defaultConfig.Settings[key];
+            if (defaultValue is JObject defaultObjectValue && defaultObjectValue["type"].ToString() == "selector")
+            {
+                var innerValue = defaultObjectValue["value"];
+                return innerValue.Type == JTokenType.Integer ? int.Parse(value.ToString()) : value;
+            }
+            return null;
         }
     }
 }

--- a/OWML.ModHelper/ModMergedConfig.cs
+++ b/OWML.ModHelper/ModMergedConfig.cs
@@ -89,18 +89,30 @@ namespace OWML.ModHelper
             }
         }
 
-        private Type GetDefaultSettingType(object defaultValue)
+        private object GetInnerValue(object outerValue)
         {
-            if (defaultValue is JObject defaultJObject)
+            if (outerValue is JObject jObject)
             {
-                return defaultJObject["value"].ToObject(typeof(object)).GetType();
+                return jObject["value"].ToObject(typeof(object));
             }
-            return defaultValue.GetType();
+            return outerValue;
+        }
+
+        private bool IsNumeric(object value)
+        {
+            var type = value.GetType();
+            var underlyingType = Nullable.GetUnderlyingType(type) ?? type;
+            return underlyingType.IsPrimitive || underlyingType == typeof(decimal);
         }
 
         private bool IsSettingConsistentWithDefault(object userValue, object defaultValue)
         {
-            return userValue.GetType() == GetDefaultSettingType(defaultValue);
+            var defaultInnerValue = GetInnerValue(defaultValue);
+            if (IsNumeric(userValue) && IsNumeric(defaultInnerValue))
+            {
+                return true;
+            }
+            return userValue.GetType() == defaultInnerValue.GetType();
         }
     }
 }

--- a/OWML.ModHelper/ModMergedConfig.cs
+++ b/OWML.ModHelper/ModMergedConfig.cs
@@ -17,14 +17,12 @@ namespace OWML.ModHelper
 
         private IModConfig _userConfig;
         private readonly IModConfig _defaultConfig;
-        private readonly IModManifest _manifest;
         private readonly IModStorage _storage;
 
         public ModMergedConfig(IModConfig userConfig, IModConfig defaultConfig, IModManifest manifest)
         {
             _userConfig = userConfig ?? new ModConfig();
             _defaultConfig = defaultConfig ?? new ModConfig();
-            _manifest = manifest;
             _storage = new ModStorage(manifest);
             FixConfigs();
         }

--- a/OWML.ModHelper/ModMergedConfig.cs
+++ b/OWML.ModHelper/ModMergedConfig.cs
@@ -11,7 +11,7 @@ namespace OWML.ModHelper
         public bool Enabled { get => _userConfig.Enabled; set => _userConfig.Enabled = value; }
         public Dictionary<string, object> Settings
         {
-            get => _defaultConfig.Settings;
+            get => GetMergedSettings();
             set => _userConfig.Settings = value;
         }
 
@@ -53,6 +53,21 @@ namespace OWML.ModHelper
         public void SaveToStorage()
         {
             _storage.Save(_userConfig, Constants.ModConfigFileName);
+        }
+
+        private Dictionary<string, object> GetMergedSettings()
+        {
+            var settings = new Dictionary<string, object>(_defaultConfig.Settings);
+            _userConfig.Settings.ToList().ForEach(x =>
+            {
+                if (settings[x.Key] is JObject jObject)
+                {
+                    jObject["value"] = JToken.FromObject(x.Value);
+                    return;
+                }
+                settings[x.Key] = x.Value;
+            });
+            return settings;
         }
 
         private void FixConfigs()

--- a/OWML.ModHelper/ModMergedConfig.cs
+++ b/OWML.ModHelper/ModMergedConfig.cs
@@ -86,7 +86,9 @@ namespace OWML.ModHelper
             return value is int
                 || value is long
                 || value is float
-                || value is double;
+                || value is double
+                || value is decimal
+                || value is ulong;
         }
 
         private bool IsSettingConsistentWithDefault(string key)

--- a/OWML.ModHelper/ModMergedConfig.cs
+++ b/OWML.ModHelper/ModMergedConfig.cs
@@ -81,11 +81,12 @@ namespace OWML.ModHelper
             settings[key] = value;
         }
 
-        private bool IsNumeric(object value)
+        private bool IsNumber(object value)
         {
-            var type = value.GetType();
-            var underlyingType = Nullable.GetUnderlyingType(type) ?? type;
-            return underlyingType.IsPrimitive || underlyingType == typeof(decimal);
+            return value is int
+                || value is long
+                || value is float
+                || value is double;
         }
 
         private bool IsSettingConsistentWithDefault(string key)
@@ -97,11 +98,8 @@ namespace OWML.ModHelper
             var userValue = _userConfig.Settings[key];
             var defaultValue = _defaultConfig.Settings[key];
             var defaultInnerValue = GetInnerValue(defaultValue);
-            if (IsNumeric(userValue) && IsNumeric(defaultInnerValue))
-            {
-                return true;
-            }
-            return userValue.GetType() == defaultInnerValue.GetType();
+            return (userValue.GetType() == defaultInnerValue.GetType())
+                || (IsNumber(userValue) && IsNumber(defaultInnerValue));
         }
 
         private void MakeConfigConsistentWithDefault()

--- a/OWML.ModHelper/ModMergedConfig.cs
+++ b/OWML.ModHelper/ModMergedConfig.cs
@@ -11,7 +11,7 @@ namespace OWML.ModHelper
         public bool Enabled { get => _userConfig.Enabled; set => _userConfig.Enabled = value; }
         public Dictionary<string, object> Settings
         {
-            get => GetMergedSettings();
+            get => _defaultConfig.Settings;
             set => _userConfig.Settings = value;
         }
 
@@ -53,13 +53,6 @@ namespace OWML.ModHelper
         public void SaveToStorage()
         {
             _storage.Save(_userConfig, Constants.ModConfigFileName);
-        }
-
-        private Dictionary<string, object> GetMergedSettings()
-        {
-            var settings = new Dictionary<string, object>(_defaultConfig.Settings);
-            _userConfig.Settings.ToList().ForEach(x => settings[x.Key] = x.Value);
-            return settings;
         }
 
         private void FixConfigs()

--- a/OWML.ModHelper/ModMergedConfig.cs
+++ b/OWML.ModHelper/ModMergedConfig.cs
@@ -95,9 +95,11 @@ namespace OWML.ModHelper
             {
                 return false;
             }
+
             var userValue = _userConfig.Settings[key];
             var defaultValue = _defaultConfig.Settings[key];
             var defaultInnerValue = GetInnerValue(defaultValue);
+
             return (userValue.GetType() == defaultInnerValue.GetType())
                 || (IsNumber(userValue) && IsNumber(defaultInnerValue));
         }

--- a/OWML.ModHelper/ModMergedConfig.cs
+++ b/OWML.ModHelper/ModMergedConfig.cs
@@ -62,33 +62,6 @@ namespace OWML.ModHelper
             return settings;
         }
 
-        private void FixConfigs()
-        {
-            MakeConfigConsistentWithDefault();
-            SaveToStorage();
-        }
-
-        private void RemoveRedundantUserConfigEntries()
-        {
-            var toRemove = _userConfig.Settings.Keys.Except(_defaultConfig.Settings.Keys).ToList();
-            toRemove.ForEach(key => _userConfig.Settings.Remove(key));
-        }
-
-        private void MakeConfigConsistentWithDefault()
-        {
-            RemoveRedundantUserConfigEntries();
-            var keysCopy = _userConfig.Settings.Keys.ToList();
-            foreach (var key in keysCopy)
-            {
-                var userValue = _userConfig.Settings[key];
-                var defaultValue = _defaultConfig.Settings[key];
-                if (!IsSettingConsistentWithDefault(userValue, defaultValue))
-                {
-                    _userConfig.Settings.Remove(key);
-                }
-            }
-        }
-
         private object GetInnerValue(object outerValue)
         {
             if (outerValue is JObject jObject)
@@ -115,14 +88,37 @@ namespace OWML.ModHelper
             return underlyingType.IsPrimitive || underlyingType == typeof(decimal);
         }
 
-        private bool IsSettingConsistentWithDefault(object userValue, object defaultValue)
+        private bool IsSettingConsistentWithDefault(string key)
         {
+            if (!_defaultConfig.Settings.ContainsKey(key))
+            {
+                return false;
+            }
+            var userValue = _userConfig.Settings[key];
+            var defaultValue = _defaultConfig.Settings[key];
             var defaultInnerValue = GetInnerValue(defaultValue);
             if (IsNumeric(userValue) && IsNumeric(defaultInnerValue))
             {
                 return true;
             }
             return userValue.GetType() == defaultInnerValue.GetType();
+        }
+
+        private void MakeConfigConsistentWithDefault()
+        {
+            _userConfig.Settings.Keys.ToList().ForEach(key =>
+            {
+                if (!IsSettingConsistentWithDefault(key))
+                {
+                    _userConfig.Settings.Remove(key);
+                }
+            });
+        }
+
+        private void FixConfigs()
+        {
+            MakeConfigConsistentWithDefault();
+            SaveToStorage();
         }
 
         private object GetConvertedSelectorValue(string key, object value)

--- a/OWML.ModHelper/ModMergedConfig.cs
+++ b/OWML.ModHelper/ModMergedConfig.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json.Linq;
 using OWML.Common;
-using OWML.Logging;
 
 namespace OWML.ModHelper
 {
@@ -60,15 +59,6 @@ namespace OWML.ModHelper
 
         private Dictionary<string, object> GetMergedSettings()
         {
-            if (_userConfig.Settings == null)
-            {
-                return _defaultConfig.Settings;
-            }
-            // TODO hm, maybe not?
-            if (_defaultConfig.Settings == null)
-            {
-                return new Dictionary<string, object>();
-            }
             var settings = new Dictionary<string, object>(_defaultConfig.Settings);
             _userConfig.Settings.ToList().ForEach(x => settings[x.Key] = x.Value);
             return settings;

--- a/OWML.ModHelper/ModMergedConfig.cs
+++ b/OWML.ModHelper/ModMergedConfig.cs
@@ -58,15 +58,7 @@ namespace OWML.ModHelper
         private Dictionary<string, object> GetMergedSettings()
         {
             var settings = new Dictionary<string, object>(_defaultConfig.Settings);
-            _userConfig.Settings.ToList().ForEach(x =>
-            {
-                if (settings[x.Key] is JObject jObject)
-                {
-                    jObject["value"] = JToken.FromObject(x.Value);
-                    return;
-                }
-                settings[x.Key] = x.Value;
-            });
+            _userConfig.Settings.ToList().ForEach(x => SetInnerValue(settings, x.Key, x.Value));
             return settings;
         }
 
@@ -104,6 +96,16 @@ namespace OWML.ModHelper
                 return jObject["value"].ToObject(typeof(object));
             }
             return outerValue;
+        }
+
+        private void SetInnerValue(Dictionary<string, object> settings, string key, object value)
+        {
+            if (settings[key] is JObject jObject)
+            {
+                jObject["value"] = JToken.FromObject(value);
+                return;
+            }
+            settings[key] = value;
         }
 
         private bool IsNumeric(object value)


### PR DESCRIPTION
Working towards #256

Some stuff still missing from this perfect config plan:
* when user changes a setting, it should only add that single setting to config.json, instead of always adding everything;
* check for inconsistencies with values of sliders and selectors (need to be within possible values);

These will be done in a separate PR