### PR TITLE
Save individual mod settings on change

### DIFF
--- a/OWML.Common/IModConfig.cs
+++ b/OWML.Common/IModConfig.cs
@@ -9,6 +9,7 @@ namespace OWML.Common
         Dictionary<string, object> Settings { get; set; }
 
         T GetSettingsValue<T>(string key);
+        object GetSettingsValue(string key);
         void SetSettingsValue(string key, object value);
     }
 }

--- a/OWML.Common/IModData.cs
+++ b/OWML.Common/IModData.cs
@@ -9,6 +9,5 @@
         bool RequireReload { get; }
 
         void UpdateSnapshot();
-        void ResetConfigToDefaults();
     }
 }

--- a/OWML.Common/IModMergedConfig.cs
+++ b/OWML.Common/IModMergedConfig.cs
@@ -3,6 +3,7 @@
     public interface IModMergedConfig : IModConfig
     {
         void SaveToStorage();
+        void Reset();
         IModConfig Copy();
     }
 }

--- a/OWML.ModHelper.Menus/ModComboInput.cs
+++ b/OWML.ModHelper.Menus/ModComboInput.cs
@@ -22,6 +22,7 @@ namespace OWML.ModHelper.Menus
             {
                 _combination = value;
                 UpdateLayout(value);
+                InvokeOnChange(value);
             }
         }
 

--- a/OWML.ModHelper.Menus/ModConfigMenu.cs
+++ b/OWML.ModHelper.Menus/ModConfigMenu.cs
@@ -21,7 +21,7 @@ namespace OWML.ModHelper.Menus
         protected override void AddInputs()
         {
             var index = 2;
-            AddConfigInput(EnabledTitle, ModData.Config.Enabled, index++, OnSettingChange(EnabledTitle));
+            AddConfigInput(EnabledTitle, ModData.Config.Enabled, index++, OnEnabledChange);
             foreach (var setting in ModData.Config.Settings)
             {
                 AddConfigInput(setting.Key, setting.Value, index++, OnSettingChange(setting.Key));
@@ -39,20 +39,6 @@ namespace OWML.ModHelper.Menus
             }
         }
 
-        protected override void OnSave()
-        {
-            ModData.Config.Enabled = (bool)GetInputValue(EnabledTitle);
-            var keys = ModData.Config.Settings.Select(x => x.Key).ToList();
-            foreach (var key in keys)
-            {
-                var value = GetInputValue(key);
-                ModData.Config.SetSettingsValue(key, value);
-            }
-            ModData.Config.SaveToStorage();
-            Mod?.Configure(ModData.Config);
-            Close();
-        }
-
         protected override void OnReset()
         {
             ModData.ResetConfigToDefaults();
@@ -64,7 +50,14 @@ namespace OWML.ModHelper.Menus
             return (object value) =>
             {
                 ModData.Config.SetSettingsValue(key, value);
+                ModData.Config.SaveToStorage();
             };
+        }
+
+        private void OnEnabledChange(object value)
+        {
+            ModData.Config.Enabled = (bool)value;
+            ModData.Config.SaveToStorage();
         }
     }
 }

--- a/OWML.ModHelper.Menus/ModConfigMenu.cs
+++ b/OWML.ModHelper.Menus/ModConfigMenu.cs
@@ -41,7 +41,7 @@ namespace OWML.ModHelper.Menus
 
         protected override void OnReset()
         {
-            ModData.ResetConfigToDefaults();
+            ModData.Config.Reset();
             UpdateUIValues();
         }
 

--- a/OWML.ModHelper.Menus/ModConfigMenu.cs
+++ b/OWML.ModHelper.Menus/ModConfigMenu.cs
@@ -1,6 +1,7 @@
 ﻿using OWML.Common;
 using System.Linq;
 using OWML.Common.Menus;
+using System;
 
 namespace OWML.ModHelper.Menus
 {
@@ -20,10 +21,10 @@ namespace OWML.ModHelper.Menus
         protected override void AddInputs()
         {
             var index = 2;
-            AddConfigInput(EnabledTitle, ModData.Config.Enabled, index++);
+            AddConfigInput(EnabledTitle, ModData.Config.Enabled, index++, OnSettingChange(EnabledTitle));
             foreach (var setting in ModData.Config.Settings)
             {
-                AddConfigInput(setting.Key, setting.Value, index++);
+                AddConfigInput(setting.Key, setting.Value, index++, OnSettingChange(setting.Key));
             }
             UpdateNavigation();
             SelectFirst();
@@ -56,6 +57,14 @@ namespace OWML.ModHelper.Menus
         {
             ModData.ResetConfigToDefaults();
             UpdateUIValues();
+        }
+
+        private Action<object> OnSettingChange(string key)
+        {
+            return (object value) =>
+            {
+                ModData.Config.SetSettingsValue(key, value);
+            };
         }
     }
 }

--- a/OWML.ModHelper.Menus/ModConfigMenuBase.cs
+++ b/OWML.ModHelper.Menus/ModConfigMenuBase.cs
@@ -3,6 +3,7 @@ using OWML.Common;
 using OWML.Common.Menus;
 using System.Linq;
 using OWML.Logging;
+using System;
 
 namespace OWML.ModHelper.Menus
 {
@@ -51,24 +52,24 @@ namespace OWML.ModHelper.Menus
             base.Open();
             UpdateUIValues();
         }
-        
-        protected void AddConfigInput(string key, object value, int index)
+
+        protected void AddConfigInput(string key, object value, int index, Action<object> onChange)
         {
             if (value is bool)
             {
-                AddToggleInput(key, index);
+                AddToggleInput(key, index, onChange);
                 return;
             }
 
             if (value is string)
             {
-                AddTextInput(key, index);
+                AddTextInput(key, index, onChange);
                 return;
             }
 
             if (new[] { typeof(long), typeof(int), typeof(float), typeof(double) }.Contains(value.GetType()))
             {
-                AddNumberInput(key, index);
+                AddNumberInput(key, index, onChange);
                 return;
             }
 
@@ -77,16 +78,16 @@ namespace OWML.ModHelper.Menus
                 switch ((string)obj["type"])
                 {
                     case "slider":
-                        AddSliderInput(key, obj, index);
+                        AddSliderInput(key, obj, index, onChange);
                         return;
                     case "toggle":
-                        AddToggleInput(key, obj, index);
+                        AddToggleInput(key, obj, index, onChange);
                         return;
                     case "selector":
-                        AddSelectorInput(key, obj, index);
+                        AddSelectorInput(key, obj, index, onChange);
                         return;
                     case "input":
-                        AddComboInput(key, index);
+                        AddComboInput(key, index, onChange);
                         return;
                     default:
                         ModConsole.OwmlConsole.WriteLine("Error - Unrecognized complex setting: " + value, MessageType.Error);
@@ -97,9 +98,10 @@ namespace OWML.ModHelper.Menus
             ModConsole.OwmlConsole.WriteLine("Error - Unrecognized setting type: " + value.GetType(), MessageType.Error);
         }
 
-        private void AddToggleInput(string key, int index)
+        private void AddToggleInput(string key, int index, Action<object> onChange)
         {
             var toggle = AddToggleInput(_toggleTemplate.Copy(key), index);
+            toggle.OnChange += value => onChange(value);
             toggle.YesButton.Title = "Yes";
             toggle.NoButton.Title = "No";
             toggle.Element.name = key;
@@ -107,9 +109,10 @@ namespace OWML.ModHelper.Menus
             toggle.Show();
         }
 
-        private void AddToggleInput(string key, JObject obj, int index)
+        private void AddToggleInput(string key, JObject obj, int index, Action<object> onChange)
         {
             var toggle = AddToggleInput(_toggleTemplate.Copy(key), index);
+            toggle.OnChange += value => onChange(value);
             toggle.YesButton.Title = (string)obj["yes"];
             toggle.NoButton.Title = (string)obj["no"];
             toggle.Element.name = key;
@@ -117,9 +120,10 @@ namespace OWML.ModHelper.Menus
             toggle.Show();
         }
 
-        private void AddSliderInput(string key, JObject obj, int index)
+        private void AddSliderInput(string key, JObject obj, int index, Action<object> onChange)
         {
             var slider = AddSliderInput(_sliderTemplate.Copy(key), index);
+            slider.OnChange += value => onChange(value);
             slider.Min = (float)obj["min"];
             slider.Max = (float)obj["max"];
             slider.Element.name = key;
@@ -127,33 +131,36 @@ namespace OWML.ModHelper.Menus
             slider.Show();
         }
 
-        private void AddSelectorInput(string key, JObject obj, int index)
+        private void AddSelectorInput(string key, JObject obj, int index, Action<object> onChange)
         {
             var options = obj["options"].ToObject<string[]>();
             var selector = AddSelectorInput(_selectorTemplate.Copy(key), index);
+            selector.OnChange += value => onChange(value);
             selector.Element.name = key;
             selector.Title = (string)obj["title"] ?? key;
             selector.Initialize((string)obj["value"], options);
             selector.Show();
         }
 
-        private void AddTextInput(string key, int index)
+        private void AddTextInput(string key, int index, Action<object> onChange)
         {
             var textInput = AddTextInput(_textInputTemplate.Copy(key), index);
+            textInput.OnChange += value => onChange(value);
             textInput.Element.name = key;
             textInput.Show();
         }
 
-        private void AddComboInput(string key, int index)
+        private void AddComboInput(string key, int index, Action<object> onChange)
         {
             var comboInput = AddComboInput(_comboInputTemplate.Copy(key), index);
             comboInput.Element.name = key;
             comboInput.Show();
         }
 
-        private void AddNumberInput(string key, int index)
+        private void AddNumberInput(string key, int index, Action<object> onChange)
         {
             var numberInput = AddNumberInput(_numberInputTemplate.Copy(key), index);
+            numberInput.OnChange += value => onChange(value);
             numberInput.Element.name = key;
             numberInput.Show();
         }

--- a/OWML.ModHelper.Menus/ModConfigMenuBase.cs
+++ b/OWML.ModHelper.Menus/ModConfigMenuBase.cs
@@ -153,6 +153,7 @@ namespace OWML.ModHelper.Menus
         private void AddComboInput(string key, int index, Action<object> onChange)
         {
             var comboInput = AddComboInput(_comboInputTemplate.Copy(key), index);
+            comboInput.OnChange += value => onChange(value);
             comboInput.Element.name = key;
             comboInput.Show();
         }

--- a/OWML.ModHelper.Menus/ModMenuWithSelectables.cs
+++ b/OWML.ModHelper.Menus/ModMenuWithSelectables.cs
@@ -32,6 +32,7 @@ namespace OWML.ModHelper.Menus
             var saveButton = GetPromptButton("UIElement-SaveAndExit");
             var resetButton = GetPromptButton("UIElement-ResetToDefaultsButton");
             var cancelButton = GetPromptButton("UIElement-DiscardChangesButton");
+            cancelButton.Hide();
 
             if (saveButton == null || resetButton == null || cancelButton == null)
             {

--- a/OWML.ModHelper.Menus/OwmlConfigMenu.cs
+++ b/OWML.ModHelper.Menus/OwmlConfigMenu.cs
@@ -1,4 +1,5 @@
 ﻿using OWML.Common;
+using System;
 
 namespace OWML.ModHelper.Menus
 {
@@ -18,7 +19,8 @@ namespace OWML.ModHelper.Menus
         protected override void AddInputs()
         {
             var index = 2;
-            AddConfigInput(BlockInputTitle, _config.BlockInput, index++);
+            // TODO take care of useless callback.
+            AddConfigInput(BlockInputTitle, _config.BlockInput, index++, (object _) => { });
             UpdateNavigation();
             SelectFirst();
         }

--- a/OWML.ModHelper/ModConfig.cs
+++ b/OWML.ModHelper/ModConfig.cs
@@ -32,8 +32,7 @@ namespace OWML.ModHelper
 
             try
             {
-                var value = setting is JObject objectValue ? objectValue["value"] : setting;
-                return type.IsEnum ? ConvertToEnum<T>(value) : (T)Convert.ChangeType(value, type);
+                return GetInnerValue<T>(setting);
             }
             catch (InvalidCastException)
             {
@@ -42,29 +41,13 @@ namespace OWML.ModHelper
             }
         }
 
-        private T ConvertToEnum<T>(object value)
+        private T GetInnerValue<T>(object outerValue)
         {
-            if (value is float || value is double)
+            if (outerValue is JObject jObject)
             {
-                var floatValue = Convert.ToDouble(value);
-                return (T)(object)(long)Math.Round(floatValue);
+                return jObject["value"].ToObject<T>();
             }
-            if (value is int || value is long)
-            {
-                return (T)value;
-            }
-
-            var valueString = Convert.ToString(value);
-
-            try
-            {
-                return (T)Enum.Parse(typeof(T), valueString, true);
-            }
-            catch (ArgumentException ex)
-            {
-                ModConsole.OwmlConsole.WriteLine($"Error - Can't convert {valueString} to enum {typeof(T)}: {ex.Message}", MessageType.Error);
-                return default;
-            }
+            return (T)Convert.ChangeType(outerValue, typeof(T));
         }
 
         public void SetSettingsValue(string key, object value)

--- a/OWML.ModHelper/ModConfig.cs
+++ b/OWML.ModHelper/ModConfig.cs
@@ -19,11 +19,15 @@ namespace OWML.ModHelper
         {
             if (!Settings.ContainsKey(key))
             {
-                ModConsole.OwmlConsole.WriteLine($"Error - Setting not found: {key}", MessageType.Error);
                 return default;
             }
 
             return GetSettingsValue<T>(key, Settings[key]);
+        }
+
+        public object GetSettingsValue(string key)
+        {
+            return GetSettingsValue<object>(key);
         }
 
         private T GetSettingsValue<T>(string key, object setting)

--- a/OWML.ModHelper/ModMergedConfig.cs
+++ b/OWML.ModHelper/ModMergedConfig.cs
@@ -38,11 +38,14 @@ namespace OWML.ModHelper
 
         public void SetSettingsValue(string key, object value)
         {
-            if (Equals(_defaultConfig.GetSettingsValue<object>(key), value))
+            if (!_defaultConfig.Settings.ContainsKey(key) || Equals(GetInnerValue(_defaultConfig.Settings[key]), value))
             {
-                return;
+                _userConfig.Settings.Remove(key);
             }
-            _userConfig.SetSettingsValue(key, GetConvertedSelectorValue(key, value) ?? value);
+            else
+            {
+                _userConfig.SetSettingsValue(key, GetConvertedSelectorValue(key, value) ?? value);
+            }
             SaveToStorage();
         }
 

--- a/OWML.ModHelper/ModMergedConfig.cs
+++ b/OWML.ModHelper/ModMergedConfig.cs
@@ -38,7 +38,7 @@ namespace OWML.ModHelper
 
         public void SetSettingsValue(string key, object value)
         {
-            if (!_defaultConfig.Settings.ContainsKey(key) || Equals(GetInnerValue(_defaultConfig.Settings[key]), value))
+            if (IsSettingValueEqual(key, value))
             {
                 _userConfig.Settings.Remove(key);
             }
@@ -91,6 +91,22 @@ namespace OWML.ModHelper
                 return;
             }
             settings[key] = value;
+        }
+
+        private bool IsSettingValueEqual(string key, object value)
+        {
+            if (!_defaultConfig.Settings.ContainsKey(key))
+            {
+                return true;
+            }
+
+            var defaultValue = GetInnerValue(_defaultConfig.Settings[key]);
+
+            if (IsNumber(value) && IsNumber(defaultValue))
+            {
+                return Convert.ToDouble(value) == Convert.ToDouble(defaultValue);
+            }
+            return Equals(GetInnerValue(_defaultConfig.Settings[key]), value);
         }
 
         private bool IsNumber(object value)

--- a/OWML.ModHelper/ModMergedConfig.cs
+++ b/OWML.ModHelper/ModMergedConfig.cs
@@ -44,7 +44,7 @@ namespace OWML.ModHelper
             }
             else
             {
-                _userConfig.SetSettingsValue(key, GetConvertedSelectorValue(key, value) ?? value);
+                _userConfig.SetSettingsValue(key, value);
             }
             SaveToStorage();
         }
@@ -149,21 +149,6 @@ namespace OWML.ModHelper
         {
             MakeConfigConsistentWithDefault();
             SaveToStorage();
-        }
-
-        private object GetConvertedSelectorValue(string key, object value)
-        {
-            if (!_defaultConfig.Settings.ContainsKey(key))
-            {
-                return null;
-            }
-            var defaultValue = _defaultConfig.Settings[key];
-            if (defaultValue is JObject defaultObjectValue && defaultObjectValue["type"].ToString() == "selector")
-            {
-                var innerValue = defaultObjectValue["value"];
-                return innerValue.Type == JTokenType.Integer ? int.Parse(value.ToString()) : value;
-            }
-            return null;
         }
     }
 }

--- a/OWML.ModHelper/ModMergedConfig.cs
+++ b/OWML.ModHelper/ModMergedConfig.cs
@@ -38,7 +38,12 @@ namespace OWML.ModHelper
 
         public void SetSettingsValue(string key, object value)
         {
+            if (Equals(_defaultConfig.GetSettingsValue<object>(key), value))
+            {
+                return;
+            }
             _userConfig.SetSettingsValue(key, GetConvertedSelectorValue(key, value) ?? value);
+            SaveToStorage();
         }
 
         public IModConfig Copy()
@@ -73,6 +78,10 @@ namespace OWML.ModHelper
 
         private void SetInnerValue(Dictionary<string, object> settings, string key, object value)
         {
+            if (!settings.ContainsKey(key))
+            {
+                return;
+            }
             if (settings[key] is JObject jObject)
             {
                 jObject["value"] = JToken.FromObject(value);

--- a/OWML.ModHelper/ModMergedConfig.cs
+++ b/OWML.ModHelper/ModMergedConfig.cs
@@ -78,9 +78,26 @@ namespace OWML.ModHelper
 
         private Dictionary<string, object> GetMergedSettings()
         {
-            var settings = new Dictionary<string, object>(_defaultConfig.Settings);
-            _userConfig.Settings.ToList().ForEach(x => SetInnerValue(settings, x.Key, x.Value));
-            return settings;
+            var mergedSettings = new Dictionary<string, object>();
+            foreach (var defaultSetting in _defaultConfig.Settings)
+            {
+                var key = defaultSetting.Key;
+                mergedSettings[key] = GetSettingValueClone(defaultSetting.Value);
+                if (_userConfig.Settings.ContainsKey(key))
+                {
+                    SetInnerValue(mergedSettings, key, _userConfig.Settings[key]);
+                }
+            }
+            return mergedSettings;
+        }
+
+        private object GetSettingValueClone(object value)
+        {
+            if (value is JObject jObject)
+            {
+                return jObject.DeepClone().ToObject<object>();
+            }
+            return value;
         }
 
         private void SetInnerValue(Dictionary<string, object> settings, string key, object value)

--- a/OWML.ModHelper/ModMergedConfig.cs
+++ b/OWML.ModHelper/ModMergedConfig.cs
@@ -70,6 +70,12 @@ namespace OWML.ModHelper
             _storage.Save(_userConfig, Constants.ModConfigFileName);
         }
 
+        public void Reset()
+        {
+            _userConfig.Settings.Clear();
+            SaveToStorage();
+        }
+
         private Dictionary<string, object> GetMergedSettings()
         {
             var settings = new Dictionary<string, object>(_defaultConfig.Settings);
@@ -91,9 +97,14 @@ namespace OWML.ModHelper
             settings[key] = value;
         }
 
+        private object GetDefaultValue(string key)
+        {
+            return _defaultConfig.GetSettingsValue(key);
+        }
+
         private bool IsSettingValueEqual(string key, object value)
         {
-            var defaultValue = _defaultConfig.GetSettingsValue(key);
+            var defaultValue = GetDefaultValue(key);
 
             if (IsNumber(value) && IsNumber(defaultValue))
             {
@@ -115,7 +126,7 @@ namespace OWML.ModHelper
         private bool IsSettingConsistentWithDefault(string key)
         {
             var userValue = _userConfig.Settings[key];
-            var defaultValue = _defaultConfig.GetSettingsValue(key);
+            var defaultValue = GetDefaultValue(key);
 
             if (userValue == null || defaultValue == null)
             {

--- a/OWML.ModHelper/ModMergedConfig.cs
+++ b/OWML.ModHelper/ModMergedConfig.cs
@@ -51,12 +51,9 @@ namespace OWML.ModHelper
             if (IsSettingValueEqual(key, value))
             {
                 _userConfig.Settings.Remove(key);
+                return;
             }
-            else
-            {
-                _userConfig.SetSettingsValue(key, value);
-            }
-            SaveToStorage();
+            _userConfig.SetSettingsValue(key, value);
         }
 
         public IModConfig Copy()

--- a/OWML.ModLoader/ModData.cs
+++ b/OWML.ModLoader/ModData.cs
@@ -26,10 +26,5 @@ namespace OWML.ModLoader
         {
             _configSnapshot = Config.Copy();
         }
-
-        public void ResetConfigToDefaults()
-        {
-            Config.Settings.Clear();
-        }
     }
 }


### PR DESCRIPTION
Saves to file every time a setting is changed, but saves only the setting being changed. Resetting a setting means removing it from user config.

After some consideration I realized that having the selectors support string, int, and Enum types was poor design. Pretty sure this was my fault too, back when Tai was developing it, I didn't realize what the repercussions would be in the code. The game's selector inputs use strings internally, and trying to work around this limitation and converting things back and forth made the code super messy (even before these PRs). So I chose to make selectors work only with strings.