### PR TITLE
Logging overhaul

### DIFF
--- a/src/OWML.Common/Interfaces/IOwmlConfig.cs
+++ b/src/OWML.Common/Interfaces/IOwmlConfig.cs
@@ -20,6 +20,8 @@
 
 		bool BlockInput { get; set; }
 
+		bool DebugMode { get; set; }
+
 		int SocketPort { get; set; }
 	}
 }

--- a/src/OWML.Common/Interfaces/Menus/IModMenu.cs
+++ b/src/OWML.Common/Interfaces/Menus/IModMenu.cs
@@ -79,9 +79,12 @@ namespace OWML.Common.Menus
 		IModSeparator AddSeparator(IModSeparator separator);
 
 		IModSeparator AddSeparator(IModSeparator separator, int index);
+		
 		IModSeparator GetSeparator(string title);
 
 		object GetInputValue(string key);
+
+		T GetInputValue<T>(string key);
 
 		void SetInputValue(string key, object value);
 

--- a/src/OWML.Common/MessageType.cs
+++ b/src/OWML.Common/MessageType.cs
@@ -14,6 +14,8 @@
 
 		Quit = 5,
 
-		Fatal = 6
+		Fatal = 6,
+		
+		Debug = 7
 	}
 }

--- a/src/OWML.Common/OwmlConfig.cs
+++ b/src/OWML.Common/OwmlConfig.cs
@@ -10,6 +10,9 @@ namespace OWML.Common
 		[JsonProperty("combinationsBlockInput")]
 		public bool BlockInput { get; set; }
 
+		[JsonProperty("debugMode")]
+		public bool DebugMode { get; set; }
+
 		[JsonIgnore]
 		public string DataPath => $"{GamePath}/OuterWilds_Data";
 

--- a/src/OWML.Launcher/OWML.DefaultConfig.json
+++ b/src/OWML.Launcher/OWML.DefaultConfig.json
@@ -1,5 +1,6 @@
 {
 	"gamePath": "C:/Program Files/Epic Games/OuterWilds",
+	"debugMode": false,
 	"combinationsBlockInput": false,
 	"socketPort": 0
 }

--- a/src/OWML.Launcher/OWML.Manifest.json
+++ b/src/OWML.Launcher/OWML.Manifest.json
@@ -2,7 +2,7 @@
 	"author": "Alek",
 	"name": "OWML",
 	"uniqueName": "Alek.OWML",
-	"version": "1.1.2",
+	"version": "1.1.3",
 	"description": "The mod loader and mod framework for Outer Wilds",
 	"minGameVersion": "1.0.7.0",
 	"maxGameVersion": "1.0.7.481"

--- a/src/OWML.Launcher/Program.cs
+++ b/src/OWML.Launcher/Program.cs
@@ -87,6 +87,6 @@ namespace OWML.Launcher
 		private static IModConsole CreateConsoleWriter(IOwmlConfig owmlConfig, IModManifest owmlManifest, bool hasConsolePort) =>
 			hasConsolePort
 				? new ModSocketOutput(owmlConfig, owmlManifest, null, new ModSocket(owmlConfig), new ProcessHelper())
-				: (IModConsole)new OutputWriter();
+				: (IModConsole)new OutputWriter(owmlConfig);
 	}
 }

--- a/src/OWML.Logging/ConsoleUtils.cs
+++ b/src/OWML.Logging/ConsoleUtils.cs
@@ -20,6 +20,7 @@ namespace OWML.Logging
 				MessageType.Message => ConsoleColor.Gray,
 				MessageType.Info => ConsoleColor.Cyan,
 				MessageType.Fatal => ConsoleColor.Magenta,
+				MessageType.Debug => ConsoleColor.Blue,
 				_ => ConsoleColor.Gray
 			};
 

--- a/src/OWML.Logging/ModConsole.cs
+++ b/src/OWML.Logging/ModConsole.cs
@@ -5,6 +5,7 @@ namespace OWML.Logging
 {
 	public abstract class ModConsole : IModConsole
 	{
+		[Obsolete("Use ModHelper.Console instead.")]
 		public static ModConsole OwmlConsole { get; private set; }
 
 		protected readonly IModLogger Logger;

--- a/src/OWML.Logging/ModLogger.cs
+++ b/src/OWML.Logging/ModLogger.cs
@@ -21,9 +21,11 @@ namespace OWML.Logging
 			}
 		}
 
+		[Obsolete("Use ModHelper.Console.WriteLine with messageType = Debug instead.")]
 		public void Log(string s) =>
 			LogInternal($"[{_manifest.Name}]: {s}");
 
+		[Obsolete("Use ModHelper.Console.WriteLine with messageType = Debug instead.")]
 		public void Log(params object[] objects) =>
 			Log(string.Join(" ", objects.Select(o => o.ToString()).ToArray()));
 

--- a/src/OWML.Logging/ModSocketOutput.cs
+++ b/src/OWML.Logging/ModSocketOutput.cs
@@ -24,24 +24,26 @@ namespace OWML.Logging
 			WriteLine(line, MessageType.Message, GetCallingType(new StackTrace()));
 		}
 
-		public override void WriteLine(string line) => 
+		public override void WriteLine(string line) =>
 			WriteLine(line, MessageType.Message, GetCallingType(new StackTrace()));
 
-		public override void WriteLine(string line, MessageType type) => 
+		public override void WriteLine(string line, MessageType type) =>
 			WriteLine(line, type, GetCallingType(new StackTrace()));
 
 		public override void WriteLine(string line, MessageType type, string senderType)
 		{
 			Logger?.Log($"{type}: {line}");
 
-			var message = new ModSocketMessage
+			if (type != MessageType.Debug || OwmlConfig.DebugMode)
 			{
-				SenderName = Manifest.Name,
-				SenderType = senderType,
-				Type = type,
-				Message = line
-			};
-			_socket.WriteToSocket(message);
+				_socket.WriteToSocket(new ModSocketMessage
+				{
+					SenderName = Manifest.Name,
+					SenderType = senderType,
+					Type = type,
+					Message = line
+				});
+			}
 
 			if (type == MessageType.Fatal)
 			{
@@ -50,7 +52,7 @@ namespace OWML.Logging
 		}
 		private void WriteLine(MessageType type, string line, string senderType) =>
 			WriteLine(line, type, senderType);
-		
+
 		private void KillProcess()
 		{
 			_socket.Close();

--- a/src/OWML.Logging/OutputWriter.cs
+++ b/src/OWML.Logging/OutputWriter.cs
@@ -6,6 +6,11 @@ namespace OWML.Logging
 {
 	public class OutputWriter : IModConsole
 	{
+		private readonly IOwmlConfig _config;
+
+		public OutputWriter(IOwmlConfig config) => 
+			_config = config;
+
 		[Obsolete("Use WriteLine(string) or WriteLine(string, MessageType) instead.")]
 		public void WriteLine(params object[] objects) =>
 			WriteLine(string.Join(" ", objects.Select(o => o.ToString()).ToArray()));
@@ -13,10 +18,15 @@ namespace OWML.Logging
 		public void WriteLine(string line) =>
 			WriteLine(line, MessageType.Message);
 
-		public void WriteLine(string line, MessageType type) => 
-			ConsoleUtils.WriteByType(type, line);
+		public void WriteLine(string line, MessageType type, string senderType) =>
+			WriteLine($"{senderType}: {line}", type);
 
-		public void WriteLine(string line, MessageType type, string senderType) => 
-			ConsoleUtils.WriteByType(type, $"{senderType}: {line}");
+		public void WriteLine(string line, MessageType type)
+		{
+			if (type != MessageType.Debug || _config.DebugMode)
+			{
+				ConsoleUtils.WriteByType(type, line);
+			}
+		}
 	}
 }

--- a/src/OWML.Logging/UnityLogger.cs
+++ b/src/OWML.Logging/UnityLogger.cs
@@ -1,46 +1,43 @@
-﻿using System.Linq;
-using OWML.Common;
+﻿using OWML.Common;
 using UnityEngine;
 
 namespace OWML.Logging
 {
 	public class UnityLogger : IUnityLogger
 	{
-		private readonly LogType[] _relevantTypes = {
-			LogType.Error,
-			LogType.Exception
-		};
-
-		private readonly IModSocket _socket;
 		private readonly IApplicationHelper _appHelper;
-		private readonly IModLogger _logger;
+		private readonly IModConsole _console;
+		private readonly IOwmlConfig _config;
 
-		public UnityLogger(IModSocket socket, IApplicationHelper appHelper, IModLogger logger)
+		public UnityLogger(IApplicationHelper appHelper, IModConsole console, IOwmlConfig config)
 		{
-			_socket = socket;
 			_appHelper = appHelper;
-			_logger = logger;
+			_console = console;
+			_config = config;
 		}
 
-		public void Start() => 
+		public void Start() =>
 			_appHelper.AddLogCallback(OnLogMessageReceived);
 
 		private void OnLogMessageReceived(string message, string stackTrace, LogType type)
 		{
-			if (!_relevantTypes.Contains(type))
+			if (type != LogType.Error
+			    && type != LogType.Exception 
+			    && !_config.DebugMode)
 			{
 				return;
 			}
 
 			var line = $"{message}. Stack trace: {stackTrace?.Trim()}";
-			_logger.Log(line);
-			_socket.WriteToSocket(new ModSocketMessage
+
+			var messageType = type switch
 			{
-				Type = MessageType.Error,
-				Message = line,
-				SenderName = "Unity",
-				SenderType = type.ToString()
-			});
+				LogType.Error => MessageType.Error,
+				LogType.Exception => MessageType.Error,
+				_ => MessageType.Debug
+			};
+
+			_console.WriteLine(line, messageType, "Unity");
 		}
 	}
 }

--- a/src/OWML.ModHelper.Events/HarmonyHelper.cs
+++ b/src/OWML.ModHelper.Events/HarmonyHelper.cs
@@ -7,15 +7,13 @@ namespace OWML.ModHelper.Events
 {
 	public class HarmonyHelper : IHarmonyHelper
 	{
-		private readonly IModLogger _logger;
 		private readonly IModConsole _console;
 		private readonly IModManifest _manifest;
 		private readonly IOwmlConfig _owmlConfig;
 		private readonly HarmonyInstance _harmony;
 
-		public HarmonyHelper(IModLogger logger, IModConsole console, IModManifest manifest, IOwmlConfig owmlConfig)
+		public HarmonyHelper(IModConsole console, IModManifest manifest, IOwmlConfig owmlConfig)
 		{
-			_logger = logger;
 			_console = console;
 			_manifest = manifest;
 			_owmlConfig = owmlConfig;
@@ -28,7 +26,7 @@ namespace OWML.ModHelper.Events
 			HarmonyInstance harmony;
 			try
 			{
-				_logger.Log($"Creating harmony instance: {_manifest.UniqueName}");
+				_console.WriteLine($"Creating harmony instance: {_manifest.UniqueName}", MessageType.Debug);
 				HarmonyInstance.DEBUG = true;
 				FileLog.logPath = $"{_owmlConfig.LogsPath}/harmony.log.txt";
 				harmony = HarmonyInstance.Create(_manifest.UniqueName);
@@ -51,7 +49,7 @@ namespace OWML.ModHelper.Events
 			MethodInfo result = null;
 			try
 			{
-				_logger.Log($"Getting method {methodName} of {targetType.Name}");
+				_console.WriteLine($"Getting method {methodName} of {targetType.Name}", MessageType.Debug);
 				result = Utils.TypeExtensions.GetAnyMethod(targetType, methodName);
 			}
 			catch (Exception ex)
@@ -129,7 +127,7 @@ namespace OWML.ModHelper.Events
 			try
 			{
 				_harmony.Patch(original, prefixMethod, postfixMethod, transpilerMethod);
-				_logger.Log($"Patched {fullName}!");
+				_console.WriteLine($"Patched {fullName}!", MessageType.Debug);
 			}
 			catch (Exception ex)
 			{

--- a/src/OWML.ModHelper.Events/ModEvents.cs
+++ b/src/OWML.ModHelper.Events/ModEvents.cs
@@ -24,17 +24,14 @@ namespace OWML.ModHelper.Events
 
 		private readonly IHarmonyHelper _harmonyHelper;
 		private readonly IModConsole _console;
-		private readonly IModLogger _logger;
 
 		public ModEvents(
-			IModLogger logger,
 			IModConsole console,
 			IHarmonyHelper harmonyHelper,
 			IModPlayerEvents playerEvents,
 			IModSceneEvents sceneEvents,
 			IModUnityEvents unityEvents)
 		{
-			_logger = logger;
 			_console = console;
 			_harmonyHelper = harmonyHelper;
 			Player = playerEvents;
@@ -50,13 +47,13 @@ namespace OWML.ModHelper.Events
 			var type = behaviour.GetType();
 			if (IsSubscribedTo(type, ev))
 			{
-				_logger.Log($"Got subscribed event: {ev} of {type.Name}");
+				_console.WriteLine($"Got subscribed event: {ev} of {type.Name}", MessageType.Debug);
 				OnEvent?.Invoke(behaviour, ev);
 				Event?.Invoke(behaviour, ev);
 			}
 			else
 			{
-				_logger.Log($"Not subscribed to: {ev} of {type.Name}");
+				_console.WriteLine($"Not subscribed to: {ev} of {type.Name}", MessageType.Debug);
 			}
 		}
 
@@ -71,7 +68,7 @@ namespace OWML.ModHelper.Events
 			var type = typeof(T);
 			if (IsSubscribedTo(type, ev))
 			{
-				_logger.Log($"Already subscribed to {ev} of {type.Name}");
+				_console.WriteLine($"Already subscribed to {ev} of {type.Name}", MessageType.Debug);
 				return;
 			}
 			AddToEventList(_subscribedEvents, type, ev);
@@ -82,7 +79,7 @@ namespace OWML.ModHelper.Events
 			var type = typeof(T);
 			if (InEventList(PatchedEvents, type, ev))
 			{
-				_logger.Log($"Event is already patched: {ev} of {type.Name}");
+				_console.WriteLine($"Event is already patched: {ev} of {type.Name}", MessageType.Debug);
 				return;
 			}
 			AddToEventList(PatchedEvents, type, ev);

--- a/src/OWML.ModHelper.Input/ModInputHandler.cs
+++ b/src/OWML.ModHelper.Input/ModInputHandler.cs
@@ -17,24 +17,28 @@ namespace OWML.ModHelper.Input
 		private const float Cooldown = 0.05f;
 		private const float TapDuration = 0.1f;
 		private const BindingFlags NonPublic = BindingFlags.NonPublic | BindingFlags.Instance;
-		
+
 		private readonly HashSet<IModInputCombination> _singlesPressed = new();
 		private readonly Dictionary<long, HashSet<IModInputCombination>> _comboRegistry = new();
 		private readonly HashSet<IModInputCombination> _toResetOnNextFrame = new();
 		private readonly int[] _blockedFrame = new int[ModInputLibrary.MaxUsefulKey];
 		private readonly int[] _gameBindingCounter = new int[ModInputLibrary.MaxUsefulKey];
-		private readonly IModLogger _logger;
 		private readonly IModConsole _console;
 
 		private HashSet<IModInputCombination> _currentCombinations = new();
 		private int _lastSingleUpdate;
 		private int _lastCombinationUpdate;
-		
-		public ModInputHandler(IModLogger logger, IModConsole console, IHarmonyHelper patcher, IOwmlConfig owmlConfig, IModEvents events, IModInputTextures inputTextures, IBindingChangeListener listener)
+
+		public ModInputHandler(
+			IModConsole console,
+			IHarmonyHelper patcher,
+			IOwmlConfig owmlConfig,
+			IModEvents events,
+			IModInputTextures inputTextures,
+			IBindingChangeListener listener)
 		{
 			Instance = this;
 			_console = console;
-			_logger = logger;
 			Textures = inputTextures;
 
 			listener.Initialize(this, events);
@@ -364,7 +368,7 @@ namespace OWML.ModHelper.Input
 					_console.WriteLine($"Failed to unregister \"{combination.FullName}\": Too long!", MessageType.Error);
 					return;
 				case RegistrationCode.AllNormal:
-					_logger.Log($"Successfully unregistered \"{combination.FullName}\"", MessageType.Success);
+					_console.WriteLine($"Successfully unregistered \"{combination.FullName}\"", MessageType.Debug);
 					return;
 			}
 		}

--- a/src/OWML.ModHelper.Menus/ModConfigMenu.cs
+++ b/src/OWML.ModHelper.Menus/ModConfigMenu.cs
@@ -41,7 +41,7 @@ namespace OWML.ModHelper.Menus
 
 		protected override void OnSave()
 		{
-			ModData.Config.Enabled = (bool)GetInputValue(EnabledTitle);
+			ModData.Config.Enabled = GetInputValue<bool>(EnabledTitle);
 			var keys = ModData.Config.Settings.Select(x => x.Key).ToList();
 			foreach (var key in keys)
 			{

--- a/src/OWML.ModHelper.Menus/ModMenu.cs
+++ b/src/OWML.ModHelper.Menus/ModMenu.cs
@@ -41,10 +41,8 @@ namespace OWML.ModHelper.Menus
 		protected LayoutGroup Layout;
 		protected IModConsole Console;
 
-		public ModMenu(IModConsole console)
-		{
+		public ModMenu(IModConsole console) =>
 			Console = console;
-		}
 
 		public virtual void Initialize(Menu menu)
 		{
@@ -81,20 +79,14 @@ namespace OWML.ModHelper.Menus
 		}
 
 		[Obsolete("Use GetTitleButton instead")]
-		public IModButton GetButton(string title)
-		{
-			return GetTitleButton(title);
-		}
+		public IModButton GetButton(string title) =>
+			GetTitleButton(title);
 
-		public IModButton GetTitleButton(string title)
-		{
-			return GetTitleButton(title, Buttons);
-		}
+		public IModButton GetTitleButton(string title) =>
+			GetTitleButton(title, Buttons);
 
-		public IModPromptButton GetPromptButton(string title)
-		{
-			return GetTitleButton(title, PromptButtons);
-		}
+		public IModPromptButton GetPromptButton(string title) =>
+			GetTitleButton(title, PromptButtons);
 
 		private T GetTitleButton<T>(string title, List<T> buttons) where T : IModButton
 		{
@@ -107,21 +99,15 @@ namespace OWML.ModHelper.Menus
 		}
 
 		[Obsolete("Use AddButton(IModButtonBase) instead.")]
-		public IModButton AddButton(IModButton button)
-		{
-			return AddButton(button, button.Index);
-		}
+		public IModButton AddButton(IModButton button) =>
+			AddButton(button, button.Index);
 
 		[Obsolete("Use AddButton(IModButtonBase, int) instead.")]
-		public virtual IModButton AddButton(IModButton button, int index)
-		{
-			return (IModButton)AddButton((IModButtonBase)button, index);
-		}
+		public virtual IModButton AddButton(IModButton button, int index) =>
+			(IModButton)AddButton((IModButtonBase)button, index);
 
-		public IModButtonBase AddButton(IModButtonBase button)
-		{
-			return AddButton(button, button.Index);
-		}
+		public IModButtonBase AddButton(IModButtonBase button) =>
+			AddButton(button, button.Index);
 
 		public virtual IModButtonBase AddButton(IModButtonBase button, int index)
 		{
@@ -135,15 +121,11 @@ namespace OWML.ModHelper.Menus
 			return button;
 		}
 
-		public IModToggleInput GetToggleInput(string title)
-		{
-			return ToggleInputs.FirstOrDefault(x => x.Title == title || x.Element.name == title);
-		}
+		public IModToggleInput GetToggleInput(string title) =>
+			ToggleInputs.FirstOrDefault(x => x.Title == title || x.Element.name == title);
 
-		public IModToggleInput AddToggleInput(IModToggleInput input)
-		{
-			return AddToggleInput(input, input.Index);
-		}
+		public IModToggleInput AddToggleInput(IModToggleInput input) =>
+			AddToggleInput(input, input.Index);
 
 		public IModToggleInput AddToggleInput(IModToggleInput input, int index)
 		{
@@ -152,15 +134,11 @@ namespace OWML.ModHelper.Menus
 			return input;
 		}
 
-		public IModSliderInput GetSliderInput(string title)
-		{
-			return SliderInputs.FirstOrDefault(x => x.Title == title || x.Element.name == title);
-		}
+		public IModSliderInput GetSliderInput(string title) =>
+			SliderInputs.FirstOrDefault(x => x.Title == title || x.Element.name == title);
 
-		public IModSliderInput AddSliderInput(IModSliderInput input)
-		{
-			return AddSliderInput(input, input.Index);
-		}
+		public IModSliderInput AddSliderInput(IModSliderInput input) =>
+			AddSliderInput(input, input.Index);
 
 		public IModSliderInput AddSliderInput(IModSliderInput input, int index)
 		{
@@ -169,15 +147,11 @@ namespace OWML.ModHelper.Menus
 			return input;
 		}
 
-		public IModSelectorInput GetSelectorInput(string title)
-		{
-			return SelectorInputs.FirstOrDefault(x => x.Title == title || x.Element.name == title);
-		}
+		public IModSelectorInput GetSelectorInput(string title) =>
+			SelectorInputs.FirstOrDefault(x => x.Title == title || x.Element.name == title);
 
-		public IModSelectorInput AddSelectorInput(IModSelectorInput input)
-		{
-			return AddSelectorInput(input, input.Index);
-		}
+		public IModSelectorInput AddSelectorInput(IModSelectorInput input) =>
+			AddSelectorInput(input, input.Index);
 
 		public IModSelectorInput AddSelectorInput(IModSelectorInput input, int index)
 		{
@@ -186,15 +160,11 @@ namespace OWML.ModHelper.Menus
 			return input;
 		}
 
-		public IModTextInput GetTextInput(string title)
-		{
-			return TextInputs.FirstOrDefault(x => x.Title == title || x.Element.name == title);
-		}
+		public IModTextInput GetTextInput(string title) =>
+			TextInputs.FirstOrDefault(x => x.Title == title || x.Element.name == title);
 
-		public IModTextInput AddTextInput(IModTextInput input)
-		{
-			return AddTextInput(input, input.Index);
-		}
+		public IModTextInput AddTextInput(IModTextInput input) =>
+			AddTextInput(input, input.Index);
 
 		public IModTextInput AddTextInput(IModTextInput input, int index)
 		{
@@ -203,15 +173,11 @@ namespace OWML.ModHelper.Menus
 			return input;
 		}
 
-		public IModComboInput GetComboInput(string title)
-		{
-			return ComboInputs.FirstOrDefault(x => x.Title == title || x.Element.name == title);
-		}
+		public IModComboInput GetComboInput(string title) =>
+			ComboInputs.FirstOrDefault(x => x.Title == title || x.Element.name == title);
 
-		public IModComboInput AddComboInput(IModComboInput input)
-		{
-			return AddComboInput(input, input.Index);
-		}
+		public IModComboInput AddComboInput(IModComboInput input) =>
+			AddComboInput(input, input.Index);
 
 		public IModComboInput AddComboInput(IModComboInput input, int index)
 		{
@@ -220,15 +186,11 @@ namespace OWML.ModHelper.Menus
 			return input;
 		}
 
-		public IModNumberInput GetNumberInput(string title)
-		{
-			return NumberInputs.FirstOrDefault(x => x.Title == title || x.Element.name == title);
-		}
+		public IModNumberInput GetNumberInput(string title) =>
+			NumberInputs.FirstOrDefault(x => x.Title == title || x.Element.name == title);
 
-		public IModNumberInput AddNumberInput(IModNumberInput input)
-		{
-			return AddNumberInput(input, input.Index);
-		}
+		public IModNumberInput AddNumberInput(IModNumberInput input) =>
+			AddNumberInput(input, input.Index);
 
 		public IModNumberInput AddNumberInput(IModNumberInput input, int index)
 		{
@@ -247,10 +209,8 @@ namespace OWML.ModHelper.Menus
 			input.Element.transform.localScale = scale;
 		}
 
-		public IModSeparator AddSeparator(IModSeparator separator)
-		{
-			return AddSeparator(separator, separator.Index);
-		}
+		public IModSeparator AddSeparator(IModSeparator separator) =>
+			AddSeparator(separator, separator.Index);
 
 		public IModSeparator AddSeparator(IModSeparator separator, int index)
 		{
@@ -264,10 +224,11 @@ namespace OWML.ModHelper.Menus
 			return separator;
 		}
 
-		public IModSeparator GetSeparator(string title)
-		{
-			return Separators.FirstOrDefault(x => x.Title == title || x.Element.name == title);
-		}
+		public IModSeparator GetSeparator(string title) =>
+			Separators.FirstOrDefault(x => x.Title == title || x.Element.name == title);
+
+		public T GetInputValue<T>(string key) =>
+			(T)GetInputValue(key);
 
 		public object GetInputValue(string key)
 		{
@@ -352,10 +313,8 @@ namespace OWML.ModHelper.Menus
 			Console.WriteLine("Error - No input found with name " + key, MessageType.Error);
 		}
 
-		protected void InvokeOnInit()
-		{
+		protected void InvokeOnInit() =>
 			OnInit?.Invoke();
-		}
 
 		public virtual void SelectFirst()
 		{
@@ -384,6 +343,5 @@ namespace OWML.ModHelper.Menus
 				.Where(x => x != null).ToList();
 			UpdateNavigation(selectables);
 		}
-
 	}
 }

--- a/src/OWML.ModHelper.Menus/OwmlConfigMenu.cs
+++ b/src/OWML.ModHelper.Menus/OwmlConfigMenu.cs
@@ -39,8 +39,8 @@ namespace OWML.ModHelper.Menus
 
 		protected override void OnSave()
 		{
-			_config.DebugMode = (bool)GetInputValue(DebugModeTitle); // todo generic
-			_config.BlockInput = (bool)GetInputValue(BlockInputTitle);
+			_config.DebugMode = GetInputValue<bool>(DebugModeTitle);
+			_config.BlockInput = GetInputValue<bool>(BlockInputTitle);
 			Storage.Save(_config, Constants.OwmlConfigFileName);
 			Close();
 		}

--- a/src/OWML.ModHelper.Menus/OwmlConfigMenu.cs
+++ b/src/OWML.ModHelper.Menus/OwmlConfigMenu.cs
@@ -5,6 +5,7 @@ namespace OWML.ModHelper.Menus
 {
 	public class OwmlConfigMenu : ModConfigMenuBase
 	{
+		private const string DebugModeTitle = "Debug mode";
 		private const string BlockInputTitle = "Mod inputs can block game actions";
 
 		private readonly IOwmlConfig _config;
@@ -24,18 +25,21 @@ namespace OWML.ModHelper.Menus
 
 		protected override void AddInputs()
 		{
-			AddConfigInput(BlockInputTitle, _config.BlockInput, 2);
+			AddConfigInput(DebugModeTitle, _config.DebugMode, 2);
+			AddConfigInput(BlockInputTitle, _config.BlockInput, 3);
 			UpdateNavigation();
 			SelectFirst();
 		}
 
 		protected override void UpdateUIValues()
 		{
+			GetToggleInput(DebugModeTitle).Value = _config.DebugMode;
 			GetToggleInput(BlockInputTitle).Value = _config.BlockInput;
 		}
 
 		protected override void OnSave()
 		{
+			_config.DebugMode = (bool)GetInputValue(DebugModeTitle); // todo generic
 			_config.BlockInput = (bool)GetInputValue(BlockInputTitle);
 			Storage.Save(_config, Constants.OwmlConfigFileName);
 			Close();
@@ -44,6 +48,7 @@ namespace OWML.ModHelper.Menus
 		protected override void OnReset()
 		{
 			_config.GamePath = _defaultConfig.GamePath;
+			_config.DebugMode = _defaultConfig.DebugMode;
 			_config.BlockInput = _defaultConfig.BlockInput;
 			UpdateUIValues();
 		}

--- a/src/OWML.ModLoader/Owo.cs
+++ b/src/OWML.ModLoader/Owo.cs
@@ -16,7 +16,6 @@ namespace OWML.ModLoader
 	public class Owo
 	{
 		private readonly IModFinder _modFinder;
-		private readonly IModLogger _logger;
 		private readonly IModConsole _console;
 		private readonly IOwmlConfig _owmlConfig;
 		private readonly IModMenus _menus;
@@ -33,7 +32,6 @@ namespace OWML.ModLoader
 
 		public Owo(
 			IModFinder modFinder,
-			IModLogger logger,
 			IModConsole console,
 			IOwmlConfig owmlConfig,
 			IModMenus menus,
@@ -48,7 +46,6 @@ namespace OWML.ModLoader
 			IModUnityEvents unityEvents)
 		{
 			_modFinder = modFinder;
-			_logger = logger;
 			_console = console;
 			_owmlConfig = owmlConfig;
 			_menus = menus;
@@ -120,13 +117,13 @@ namespace OWML.ModLoader
 		{
 			if (!modData.Config.Enabled)
 			{
-				_logger.Log($"{modData.Manifest.UniqueName} is disabled");
+				_console.WriteLine($"{modData.Manifest.UniqueName} is disabled", MessageType.Debug);
 				return null;
 			}
 
-			_logger.Log($"Loading assembly: {modData.Manifest.AssemblyPath}");
+			_console.WriteLine($"Loading assembly: {modData.Manifest.AssemblyPath}", MessageType.Debug);
 			var assembly = Assembly.LoadFile(modData.Manifest.AssemblyPath);
-			_logger.Log($"Loaded {assembly.FullName}");
+			_console.WriteLine($"Loaded {assembly.FullName}", MessageType.Debug);
 
 			try
 			{
@@ -166,12 +163,12 @@ namespace OWML.ModLoader
 
 		private IModBehaviour InitializeMod(Type modType, IModHelper helper)
 		{
-			_logger.Log($"Initializing {helper.Manifest.UniqueName} ({helper.Manifest.Version})...");
-			_logger.Log("Adding mod behaviour...");
+			_console.WriteLine($"Initializing {helper.Manifest.UniqueName} ({helper.Manifest.Version})...", MessageType.Debug);
+			_console.WriteLine("Adding mod behaviour...", MessageType.Debug);
 			try
 			{
 				var mod = _goHelper.CreateAndAdd<IModBehaviour>(modType, helper.Manifest.UniqueName);
-				_logger.Log("Added! Initializing...");
+				_console.WriteLine("Added! Initializing...", MessageType.Debug);
 				mod.Init(helper);
 				return mod;
 			}

--- a/src/OWML.Patcher/VRPatcher.cs
+++ b/src/OWML.Patcher/VRPatcher.cs
@@ -8,7 +8,7 @@ namespace OWML.Patcher
 		private readonly IOwmlConfig _owmlConfig;
 		private readonly IBinaryPatcher _binaryPatcher;
 		private readonly IVRFilePatcher _vrFilePatcher;
-		private readonly IModLogger _logger;
+		private readonly IModConsole _console;
 
 		private static readonly string[] PluginFilenames =
 		{
@@ -16,25 +16,25 @@ namespace OWML.Patcher
 			"OVRPlugin.dll"
 		};
 
-		public VRPatcher(IOwmlConfig owmlConfig, IBinaryPatcher binaryPatcher, IVRFilePatcher vrFilePatcher, IModLogger logger)
+		public VRPatcher(IOwmlConfig owmlConfig, IBinaryPatcher binaryPatcher, IVRFilePatcher vrFilePatcher, IModConsole console)
 		{
 			_owmlConfig = owmlConfig;
 			_binaryPatcher = binaryPatcher;
 			_vrFilePatcher = vrFilePatcher;
-			_logger = logger;
+			_console = console;
 		}
 
 		public void PatchVR(bool enableVR)
 		{
 			if (enableVR)
 			{
-				_logger.Log("Patching globalgamemanagers for VR and adding VR plugins");
+				_console.WriteLine("Patching globalgamemanagers for VR and adding VR plugins", MessageType.Debug);
 				_vrFilePatcher.Patch();
 				AddPluginFiles();
 			}
 			else
 			{
-				_logger.Log("Restoring globalgamemanagers and removing VR plugins");
+				_console.WriteLine("Restoring globalgamemanagers and removing VR plugins", MessageType.Debug);
 				_binaryPatcher.RestoreFromBackup();
 				RemovePluginFiles();
 			}
@@ -46,7 +46,7 @@ namespace OWML.Patcher
 			{
 				var from = $"{_owmlConfig.OWMLPath}lib/{filename}";
 				var to = $"{_owmlConfig.PluginsPath}/{filename}";
-				_logger.Log($"Copying {from} to {to}");
+				_console.WriteLine($"Copying {from} to {to}", MessageType.Debug);
 				File.Copy(from, to, true);
 			}
 		}
@@ -58,12 +58,12 @@ namespace OWML.Patcher
 				var path = $"{_owmlConfig.PluginsPath}/{filename}";
 				if (File.Exists(path))
 				{
-					_logger.Log($"Deleting {path}");
+					_console.WriteLine($"Deleting {path}", MessageType.Debug);
 					File.Delete(path);
 				}
 				else
 				{
-					_logger.Log($"{path} doesn't exist, nothing to delete.");
+					_console.WriteLine($"{path} doesn't exist, nothing to delete.", MessageType.Debug);
 				}
 			}
 		}

--- a/src/SampleMods/OWML.LoadCustomAssets/LoadCustomAssets.cs
+++ b/src/SampleMods/OWML.LoadCustomAssets/LoadCustomAssets.cs
@@ -74,6 +74,7 @@ namespace OWML.LoadCustomAssets
 			ModHelper.Console.WriteLine("Test Message", MessageType.Message);
 			ModHelper.Console.WriteLine("Test Success", MessageType.Success);
 			ModHelper.Console.WriteLine("Test Info", MessageType.Info);
+			ModHelper.Console.WriteLine("Test Debug", MessageType.Debug);
 		}
 
 		private void OnMusicLoaded(AudioSource audio)


### PR DESCRIPTION
* New OWML config (available in OWML menu): Debug mode.
* When Debug mode is enabled, *everything* is written to the console (in blue), including what was previously only written to log files and all Unity messages.
* Deprecated Logger.Log, use Console.WriteLine with messageType = Debug instead.