### PR TITLE
ModLogger has an [Obsolete] attribute on public void Log, but the IModLogger interface does not.

### DIFF
--- a/src/OWML.Common/Interfaces/IModLogger.cs
+++ b/src/OWML.Common/Interfaces/IModLogger.cs
@@ -1,9 +1,13 @@
-﻿namespace OWML.Common
+﻿using System;
+
+namespace OWML.Common
 {
 	public interface IModLogger
 	{
+		[Obsolete("Use ModHelper.Console.WriteLine with messageType = Debug instead.")]
 		void Log(string s);
 
+		[Obsolete("Use ModHelper.Console.WriteLine with messageType = Debug instead.")]
 		void Log(params object[] s);
 	}
 }


### PR DESCRIPTION
Fixes #458