### PR TITLE
Stop tabbed menu from logging all the time

### DIFF
--- a/src/OWML.ModLoader/Owo.cs
+++ b/src/OWML.ModLoader/Owo.cs
@@ -30,6 +30,7 @@ namespace OWML.ModLoader
 		private readonly IModUnityEvents _unityEvents;
 		private readonly IModManifest _owmlManifest;
 		private readonly IModVersionChecker _modVersionChecker;
+		private readonly IHarmonyHelper _harmonyHelper;
 		private readonly IList<IModBehaviour> _modList = new List<IModBehaviour>();
 
 		public Owo(
@@ -45,7 +46,8 @@ namespace OWML.ModLoader
 			IApplicationHelper appHelper,
 			IProcessHelper processHelper,
 			IModUnityEvents unityEvents,
-			IModVersionChecker modVersionChecker)
+			IModVersionChecker modVersionChecker,
+			IHarmonyHelper harmonyHelper)
 		{
 			_modFinder = modFinder;
 			_console = console;
@@ -60,6 +62,7 @@ namespace OWML.ModLoader
 			_processHelper = processHelper;
 			_unityEvents = unityEvents;
 			_modVersionChecker = modVersionChecker;
+			_harmonyHelper = harmonyHelper;
 			_owmlManifest = JsonHelper.LoadJsonObject<ModManifest>($"{_owmlConfig.ManagedPath}/{Constants.OwmlManifestFileName}");
 		}
 

--- a/src/OWML.ModLoader/Owo.cs
+++ b/src/OWML.ModLoader/Owo.cs
@@ -73,6 +73,7 @@ namespace OWML.ModLoader
 
 			_goHelper.CreateAndAdd<OwmlBehaviour>();
 			_unityLogger.Start();
+			_harmonyHelper.AddPrefix<TabbedMenu>(nameof(TabbedMenu.OnUpdateInputDevice), typeof(Owo), nameof(TabbedMenu_OnUpdateInputDevice));
 			var mods = _modFinder.GetMods();
 
 			var changedSettings = mods.Where(mod => mod.FixConfigs()).Select(mod => mod.Manifest.Name).ToArray();
@@ -215,6 +216,15 @@ namespace OWML.ModLoader
 				_console.WriteLine($"Error while adding/initializing {helper.Manifest.UniqueName}: {ex}", MessageType.Error);
 				return null;
 			}
+		}
+
+		private static bool TabbedMenu_OnUpdateInputDevice(TabbedMenu __instance)
+		{
+			if ((object)__instance == null) return false;
+			if (__instance == null) return false;
+			if (__instance.gameObject == null) return false;
+			if (Utils.TypeExtensions.GetValue<UnityEngine.UI.Image>(__instance, "_tabLeftButtonImg") == null || Utils.TypeExtensions.GetValue<UnityEngine.UI.Image>(__instance, "_tabRightButtonImg") == null) return false;
+			return true;
 		}
 	}
 }


### PR DESCRIPTION
I have no idea why but anytime I press any button on my keyboard, the logs are spammed with this message. It even happens without any mods.
```
Serialized Field _tabLeftButtonImg/_tabRightButtonImg Not Set!
```
So I figured out a way to stop the logging from happening. I'm not sure why it happens though.

There is probably a better way to fix this but this is all I could think of.