### PR TITLE
Fix harmony dependency in nuget

### DIFF
--- a/src/OWML.ModHelper/OWML.ModHelper.nuspec
+++ b/src/OWML.ModHelper/OWML.ModHelper.nuspec
@@ -15,7 +15,7 @@
     <tags>Outer Wilds</tags>
     <dependencies>
       <group targetFramework=".NETFramework3.5">
-        <dependency id="Lib.Harmony" version="1.2.0.1" />
+        <dependency id="HarmonyX" version="2.5.5" />
         <dependency id="Json.Net.Unity3D" version="9.0.1" />
       </group>
     </dependencies>


### PR DESCRIPTION
1.2.0.1 doesn't use HarmonyLib as a namespace

It should be HarmonyX instead of regular harmony
That is what HarmonyHelper uses after all